### PR TITLE
feat(ci): run slither in main workflow

### DIFF
--- a/.github/sripts/slither-comment.js
+++ b/.github/sripts/slither-comment.js
@@ -1,0 +1,24 @@
+module.exports = async ({ github, context, header, body }) => {
+    const comment = [header, body].join("\n")
+
+    const { data: comments } = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.payload.number
+    })
+
+    const botComment = comments.find(
+        (comment) =>
+            // github-actions bot user
+            comment.user.id === 41898282 && comment.body.startsWith(header)
+    )
+
+    const commentFn = botComment ? "updateComment" : "createComment"
+
+    await github.rest.issues[commentFn]({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: comment,
+        ...(botComment ? { comment_id: botComment.id } : { issue_number: context.payload.number })
+    })
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     deps:
         runs-on: ubuntu-latest
         outputs:
-            cache-path: ${{ steps.cache-env.outputs.cache-path }}
             cache-key: ${{ steps.cache-env.outputs.cache-key }}
         steps:
             - uses: actions/checkout@v4
@@ -24,16 +23,14 @@ jobs:
 
             - name: Get yarn cache directory path
               id: cache-env
-              run: |
-                  echo "cache-path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-                  echo "cache-key=${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
+              run: echo "cache-key=${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
 
             - uses: actions/cache@v4
               id: cache
               with:
-                  path: ${{ steps.cache-env.outputs.cache-path }}
+                  path: node_modules
                   key: ${{ steps.cache-env.outputs.cache-key }}
-                  restore-keys: ${{ runner.os }}-yarn-
+                  restore-keys: ${{ runner.os }}-node_modules-
 
             - if: steps.cache.outputs.cache-hit != 'true'
               run: yarn
@@ -61,7 +58,7 @@ jobs:
                   node-version: "20"
             - uses: actions/cache/restore@v4
               with:
-                  path: ${{ needs.deps.outputs.cache-path }}
+                  path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
 
             - run: yarn compile
@@ -82,7 +79,7 @@ jobs:
                   node-version: "20"
             - uses: actions/cache/restore@v4
               with:
-                  path: ${{ needs.deps.outputs.cache-path }}
+                  path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
 
             - run: yarn format
@@ -97,7 +94,7 @@ jobs:
                   node-version: "20"
             - uses: actions/cache/restore@v4
               with:
-                  path: ${{ needs.deps.outputs.cache-path }}
+                  path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
             - uses: actions/download-artifact@v4
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
             - run: yarn format
     tests:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: compile
+        needs: [deps, compile]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
                   sarif: results.sarif
                   fail-on: none
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
-                  target: ${{ matrix.dir }}
+                  target: packages/${{ matrix.dir }}
             - name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,9 +100,10 @@ jobs:
               uses: crytic/slither-action@v0.4.0
               id: slither
               with:
-                  sarif: results.sarif
+                  ignore-compile: true
                   fail-on: none
-                  slither-args: --ignore-compile --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
+                  sarif: results.sarif
+                  slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
             - name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,117 +50,117 @@ jobs:
               with:
                   files: packages/**/*.{sol,json,ts}
 
-    # compile:
-    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-    #     needs: [get-changed-files, deps]
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - uses: actions/setup-node@v4
-    #           with:
-    #               node-version: "20"
-    #         - uses: actions/cache/restore@v4
-    #           with:
-    #               path: ${{ needs.deps.outputs.cache-path }}
-    #               key: ${{ needs.deps.outputs.cache-key }}
+    compile:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        needs: [get-changed-files, deps]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
 
-    #         - run: yarn compile
+            - run: yarn compile
 
-    #         - name: Upload compilation results
-    #           uses: actions/upload-artifact@v4
-    #           with:
-    #               name: all-artifacts
-    #               path: packages/**/artifacts/**
+            - name: Upload compilation results
+              uses: actions/upload-artifact@v4
+              with:
+                  name: all-artifacts
+                  path: packages/**/artifacts/**
 
-    # style:
-    #     needs: deps
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - uses: actions/setup-node@v4
-    #           with:
-    #               node-version: "20"
-    #         - uses: actions/cache/restore@v4
-    #           with:
-    #               path: ${{ needs.deps.outputs.cache-path }}
-    #               key: ${{ needs.deps.outputs.cache-key }}
+    style:
+        needs: deps
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
 
-    #         - run: yarn format
-    # tests:
-    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-    #     needs: compile
-    #     runs-on: ubuntu-latest
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - uses: actions/setup-node@v4
-    #           with:
-    #               node-version: "20"
-    #         - uses: actions/cache/restore@v4
-    #           with:
-    #               path: ${{ needs.deps.outputs.cache-path }}
-    #               key: ${{ needs.deps.outputs.cache-key }}
-    #         - uses: actions/download-artifact@v4
-    #           with:
-    #               name: all-artifacts
-    #               path: packages/
+            - run: yarn format
+    tests:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        needs: compile
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
+            - uses: actions/download-artifact@v4
+              with:
+                  name: all-artifacts
+                  path: packages/
 
-    #         - run: yarn test
+            - run: yarn test
 
-    #         - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    #           name: Coveralls
-    #           uses: coverallsapp/github-action@v2
-    #           with:
-    #               github-token: ${{ secrets.GITHUB_TOKEN }}
+            - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              name: Coveralls
+              uses: coverallsapp/github-action@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    # set-slither-matrix:
-    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-    #     needs: get-changed-files
-    #     runs-on: ubuntu-latest
-    #     outputs:
-    #         matrix: ${{ steps.set-matrix.outputs.matrix }}
-    #     steps:
-    #         - uses: actions/checkout@v4
-    #         - name: Set matrix
-    #           id: set-matrix
-    #           run: |
-    #               matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
-    #               echo "matrix=$matrix" >> $GITHUB_OUTPUT
+    set-slither-matrix:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        needs: get-changed-files
+        runs-on: ubuntu-latest
+        outputs:
+            matrix: ${{ steps.set-matrix.outputs.matrix }}
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set matrix
+              id: set-matrix
+              run: |
+                  matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
+                  echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-    # slither:
-    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-    #     needs: [set-slither-matrix, compile]
-    #     runs-on: ubuntu-latest
-    #     permissions:
-    #         contents: read
-    #         security-events: write
-    #     strategy:
-    #         matrix:
-    #             dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
-    #     steps:
-    #         - uses: actions/checkout@v4
+    slither:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        needs: [set-slither-matrix, compile]
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            security-events: write
+        strategy:
+            matrix:
+                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
+        steps:
+            - uses: actions/checkout@v4
 
-    #         - name: Run slither
-    #           uses: crytic/slither-action@v0.4.0
-    #           id: slither
-    #           with:
-    #               ignore-compile: true
-    #               fail-on: none
-    #               sarif: results.sarif
-    #               slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
-    #               target: packages/${{ matrix.dir }}
-    #         - name: Upload SARIF files
-    #           uses: github/codeql-action/upload-sarif@v3
-    #           with:
-    #               sarif_file: ${{ steps.slither.outputs.sarif }}
+            - name: Run slither
+              uses: crytic/slither-action@v0.4.0
+              id: slither
+              with:
+                  ignore-compile: true
+                  fail-on: none
+                  sarif: results.sarif
+                  slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
+                  target: packages/${{ matrix.dir }}
+            - name: Upload SARIF files
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: ${{ steps.slither.outputs.sarif }}
 
-    #         - name: Create/update checklist as PR comment
-    #           uses: actions/github-script@v7
-    #           if: github.even_name == 'pull_request'
-    #           env:
-    #               REPORT: ${{ steps.slither.stdout }}
-    #           with:
-    #               script: |
-    #                   const script = require('.github/scripts/slither-comment')
-    #                   const header = '# Slither report'
-    #                   const body = process.env.REPORT
-    #                   await script({ github, context, header, body })
+            - name: Create/update checklist as PR comment
+              uses: actions/github-script@v7
+              if: github.even_name == 'pull_request'
+              env:
+                  REPORT: ${{ steps.slither.stdout }}
+              with:
+                  script: |
+                      const script = require('.github/scripts/slither-comment')
+                      const header = '# Slither report'
+                      const body = process.env.REPORT
+                      await script({ github, context, header, body })

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
               name: Test
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
-                  yarn worksace "$workspace" run test:coverage
+                  yarn workspace "$workspace" run test:coverage
 
             - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               name: Coveralls

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,12 +72,11 @@ jobs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
         steps:
             - uses: actions/checkout@v4
-            - name: set-matrix
-              id: get-dirs
+            - name: Set matrix
+              id: set-matrix
               run: |
-                matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
-                echo "$matrix"
-                echo "matrix" >> $GITHUB_OUTPUT
+                  matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
+                  echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
         needs: set-slither-matrix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,117 +50,117 @@ jobs:
               with:
                   files: packages/**/*.{sol,json,ts}
 
-    compile:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [get-changed-files, deps]
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-            - uses: actions/cache/restore@v4
-              with:
-                  path: ${{ needs.deps.outputs.cache-path }}
-                  key: ${{ needs.deps.outputs.cache-key }}
+    # compile:
+    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+    #     needs: [get-changed-files, deps]
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - uses: actions/setup-node@v4
+    #           with:
+    #               node-version: "20"
+    #         - uses: actions/cache/restore@v4
+    #           with:
+    #               path: ${{ needs.deps.outputs.cache-path }}
+    #               key: ${{ needs.deps.outputs.cache-key }}
 
-            - run: yarn compile
+    #         - run: yarn compile
 
-            - name: Upload compilation results
-              uses: actions/upload-artifact@v4
-              with:
-                  name: all-artifacts
-                  path: packages/**/artifacts/**
+    #         - name: Upload compilation results
+    #           uses: actions/upload-artifact@v4
+    #           with:
+    #               name: all-artifacts
+    #               path: packages/**/artifacts/**
 
-    style:
-        needs: deps
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-            - uses: actions/cache/restore@v4
-              with:
-                  path: ${{ needs.deps.outputs.cache-path }}
-                  key: ${{ needs.deps.outputs.cache-key }}
+    # style:
+    #     needs: deps
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - uses: actions/setup-node@v4
+    #           with:
+    #               node-version: "20"
+    #         - uses: actions/cache/restore@v4
+    #           with:
+    #               path: ${{ needs.deps.outputs.cache-path }}
+    #               key: ${{ needs.deps.outputs.cache-key }}
 
-            - run: yarn format
-    tests:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: compile
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-            - uses: actions/cache/restore@v4
-              with:
-                  path: ${{ needs.deps.outputs.cache-path }}
-                  key: ${{ needs.deps.outputs.cache-key }}
-            - uses: actions/download-artifact@v4
-              with:
-                  name: all-artifacts
-                  path: packages/
+    #         - run: yarn format
+    # tests:
+    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+    #     needs: compile
+    #     runs-on: ubuntu-latest
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - uses: actions/setup-node@v4
+    #           with:
+    #               node-version: "20"
+    #         - uses: actions/cache/restore@v4
+    #           with:
+    #               path: ${{ needs.deps.outputs.cache-path }}
+    #               key: ${{ needs.deps.outputs.cache-key }}
+    #         - uses: actions/download-artifact@v4
+    #           with:
+    #               name: all-artifacts
+    #               path: packages/
 
-            - run: yarn test
+    #         - run: yarn test
 
-            - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-              name: Coveralls
-              uses: coverallsapp/github-action@v2
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
+    #         - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    #           name: Coveralls
+    #           uses: coverallsapp/github-action@v2
+    #           with:
+    #               github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    set-slither-matrix:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: get-changed-files
-        runs-on: ubuntu-latest
-        outputs:
-            matrix: ${{ steps.set-matrix.outputs.matrix }}
-        steps:
-            - uses: actions/checkout@v4
-            - name: Set matrix
-              id: set-matrix
-              run: |
-                  matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
-                  echo "matrix=$matrix" >> $GITHUB_OUTPUT
+    # set-slither-matrix:
+    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+    #     needs: get-changed-files
+    #     runs-on: ubuntu-latest
+    #     outputs:
+    #         matrix: ${{ steps.set-matrix.outputs.matrix }}
+    #     steps:
+    #         - uses: actions/checkout@v4
+    #         - name: Set matrix
+    #           id: set-matrix
+    #           run: |
+    #               matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
+    #               echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-    slither:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [set-slither-matrix, compile]
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            security-events: write
-        strategy:
-            matrix:
-                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
-        steps:
-            - uses: actions/checkout@v4
+    # slither:
+    #     if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+    #     needs: [set-slither-matrix, compile]
+    #     runs-on: ubuntu-latest
+    #     permissions:
+    #         contents: read
+    #         security-events: write
+    #     strategy:
+    #         matrix:
+    #             dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
+    #     steps:
+    #         - uses: actions/checkout@v4
 
-            - name: Run slither
-              uses: crytic/slither-action@v0.4.0
-              id: slither
-              with:
-                  ignore-compile: true
-                  fail-on: none
-                  sarif: results.sarif
-                  slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
-                  target: packages/${{ matrix.dir }}
-            - name: Upload SARIF files
-              uses: github/codeql-action/upload-sarif@v3
-              with:
-                  sarif_file: ${{ steps.slither.outputs.sarif }}
+    #         - name: Run slither
+    #           uses: crytic/slither-action@v0.4.0
+    #           id: slither
+    #           with:
+    #               ignore-compile: true
+    #               fail-on: none
+    #               sarif: results.sarif
+    #               slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
+    #               target: packages/${{ matrix.dir }}
+    #         - name: Upload SARIF files
+    #           uses: github/codeql-action/upload-sarif@v3
+    #           with:
+    #               sarif_file: ${{ steps.slither.outputs.sarif }}
 
-            - name: Create/update checklist as PR comment
-              uses: actions/github-script@v7
-              if: github.even_name == 'pull_request'
-              env:
-                  REPORT: ${{ steps.slither.stdout }}
-              with:
-                  script: |
-                      const script = require('.github/scripts/slither-comment')
-                      const header = '# Slither report'
-                      const body = process.env.REPORT
-                      await script({ github, context, header, body })
+    #         - name: Create/update checklist as PR comment
+    #           uses: actions/github-script@v7
+    #           if: github.even_name == 'pull_request'
+    #           env:
+    #               REPORT: ${{ steps.slither.stdout }}
+    #           with:
+    #               script: |
+    #                   const script = require('.github/scripts/slither-comment')
+    #                   const header = '# Slither report'
+    #                   const body = process.env.REPORT
+    #                   await script({ github, context, header, body })

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,3 +65,52 @@ jobs:
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    gen-slither-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            matrix: ${{ steps.set-matrix.outputs.matrix }}
+        steps:
+            - uses: actions/checkout@v4
+            - name: get list of packages
+              run: |
+                  dirs=$(ls -1 packages)
+                  dirs_json=$(printf '%s\n' "$dirs" | jq -R . | jq -s .)
+                  echo "$dirs_json" >> $GITHUB_ENV
+            - name: set matrix
+              run: echo "::set-output name=matrix::${{ env.dirs_json }}"
+
+    slither:
+        needs: gen-slither-matrix
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            security-events: write
+        strategy:
+            matrix:
+                dir: ${{ fromJson(needs.gen-slither.matrix.outputs.matrix) }}
+        steps:
+            - uses: actions/checkout@v4
+            - name: Run slither
+              uses: crytic/slityer-action@v0.4.0
+              id: slither
+              with:
+                  sarif: results.sarif
+                  fail-on: none
+                  slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
+                  target: ${{ matrix.dir }}
+            - name: Upload SARIF files
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                  sarif_file: ${{ steps.slither.outputs.sarif }}
+            - name: Create/update checklist as PR comment
+              uses: actions/github-script@v7
+              if: github.even_name == 'pull_request'
+              env:
+                  REPORT: ${{ steps.slither.stdout }}
+              with:
+                  script: |
+                      const script = require('.github/scripts/slither-comment')
+                      const header = '# Slither report'
+                      const body = process.env.REPORT
+                      await script({ github, context, header, body })

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,13 +89,20 @@ jobs:
                 dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: yarn
+            - run: yarn
+            - run: yarn compile
+
             - name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
               with:
                   sarif: results.sarif
                   fail-on: none
-                  slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
+                  slither-args: --ignore-compile --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
             - name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,11 @@ jobs:
             - if: steps.cache.outputs.cache-hit != 'true'
               run: yarn
 
-    get-changed-files:
+    changed-files:
         runs-on: ubuntu-latest
         outputs:
             any_changed: ${{ steps.changed-files.outputs.any_changed }}
+            modified_files: ${{ steps.changed-files.outputs.modified_files }}
         steps:
             - uses: actions/checkout@v4
             - name: Get changed files
@@ -47,8 +48,8 @@ jobs:
                   files: packages/**/*.{sol,json,ts}
 
     compile:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [get-changed-files, deps]
+        if: needs.changed-files.outputs.any_changed == 'true'
+        needs: [changed-files, deps]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -83,8 +84,8 @@ jobs:
 
             - run: yarn format
     tests:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [get-changed-files, set-matrix, deps, compile]
+        if: needs.changed-files.outputs.any_changed == 'true'
+        needs: [changed-files, set-matrix, deps, compile]
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -104,7 +105,7 @@ jobs:
                   name: all-artifacts
                   path: packages/
 
-            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Test
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
@@ -117,8 +118,8 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     set-matrix:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: get-changed-files
+        if: needs.changed-files.outputs.any_changed == 'true'
+        needs: changed-files
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -131,8 +132,8 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [get-changed-files, set-matrix, deps]
+        if: needs.changed-files.outputs.any_changed == 'true'
+        needs: [changed-files, set-matrix, deps]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -156,13 +157,13 @@ jobs:
               with:
                   path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
-            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Compile contracts
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 
-            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
@@ -174,7 +175,7 @@ jobs:
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
 
-            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,11 +84,11 @@ jobs:
             - run: yarn format
     tests:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [deps, compile]
+        needs: [get-changed-files, set-matrix, deps, compile]
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
+                dir: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
 
         steps:
             - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    set-slither-matrix:
+    set-matrix:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: get-changed-files
         runs-on: ubuntu-latest
@@ -132,14 +132,14 @@ jobs:
 
     slither:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [set-slither-matrix, deps]
+        needs: [get-changed-files, set-matrix, deps]
         runs-on: ubuntu-latest
         permissions:
             contents: read
             security-events: write
         strategy:
             matrix:
-                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
+                dir: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
               with:
                   node-version: "20"
 
-            - name: Get yarn cache directory path
+            - name: Output cache key
               id: cache-env
               run: echo "cache-key=${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,10 @@ jobs:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: [deps, compile]
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
+
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
@@ -100,7 +104,11 @@ jobs:
                   name: all-artifacts
                   path: packages/
 
-            - run: yarn test
+            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+              name: Test
+              run: |
+                  workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
+                  yarn worksace "$workspace" run test:coverage
 
             - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               name: Coveralls
@@ -148,7 +156,9 @@ jobs:
               with:
                   path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
-            - run: |
+            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+              name: Compile contracts
+              run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
-        if: ${{ needs.get-changed-files.outputs.any_changed = 'true' }}
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: set-slither-matrix
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,9 @@ jobs:
                 dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node_version: "20"
 
             - name: Run slither
               uses: crytic/slither-action@v0.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,8 +11,37 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    deps:
+        runs-on: ubuntu-latest
+        outputs:
+            cache-path: ${{ steps.cache-env.outputs.cache-path }}
+            cache-key: ${{ steps.cache-env.outputs.cache-key }}
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+
+            - name: Get yarn cache directory path
+              id: cache-env
+              run: |
+                  echo "cache-path=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+                  echo "cache-key=${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}" >> $GITHUB_OUTPUT
+
+            - uses: actions/cache@v4
+              id: cache
+              with:
+                  path: ${{ steps.cache-env.outputs.cache-path }}
+                  key: ${{ steps.cache-env.outputs.cache-key }}
+                  restore-keys: ${{ runner.os }}-yarn-
+
+            - if: steps.cache.outputs.cache-hit != 'true'
+              run: yarn
+
     get-changed-files:
         runs-on: ubuntu-latest
+        outputs:
+            any_changed: ${{ steps.changed-files.outputs.any_changed }}
         steps:
             - uses: actions/checkout@v4
             - name: Get changed files
@@ -22,49 +51,59 @@ jobs:
                   files: packages/**/*.{sol,json,ts}
 
     compile:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        needs: [get-changed-files, deps]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
                   node-version: "20"
-                  cache: yarn
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
 
-            - run: yarn
             - run: yarn compile
 
             - name: Upload compilation results
-              uses: actions/upload-artifacts@v4
+              uses: actions/upload-artifact@v4
               with:
                   name: all-artifacts
                   path: packages/**/artifacts/**
 
     style:
+        needs: deps
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
                   node-version: "20"
-                  cache: yarn
-            - run: yarn
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
+
             - run: yarn format
     tests:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        needs: compile
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
                   node-version: "20"
-                  cache: yarn
+            - uses: actions/cache/restore@v4
+              with:
+                  path: ${{ needs.deps.outputs.cache-path }}
+                  key: ${{ needs.deps.outputs.cache-key }}
             - uses: actions/download-artifact@v4
               with:
                   name: all-artifacts
                   path: packages/
-            - run: yarn compile
-            - run: yarn
+
             - run: yarn test
 
             - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -74,6 +113,7 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     set-slither-matrix:
+        needs: get-changed-files
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         runs-on: ubuntu-latest
         outputs:
@@ -87,8 +127,8 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
-        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: set-slither-matrix
+        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        needs: [set-slither-matrix, compile]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -98,10 +138,6 @@ jobs:
                 dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-                  cache: yarn
 
             - name: Run slither
               uses: crytic/slither-action@v0.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
                   files: packages/**/*.{sol,json,ts}
 
     compile:
-        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: [get-changed-files, deps]
         runs-on: ubuntu-latest
         steps:
@@ -87,7 +87,7 @@ jobs:
 
             - run: yarn format
     tests:
-        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: compile
         runs-on: ubuntu-latest
         steps:
@@ -113,8 +113,8 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     set-slither-matrix:
-        needs: get-changed-files
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        needs: get-changed-files
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -127,7 +127,7 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
-        if: ${{ needs.get-changed-files.outputs.any_changed }}
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         needs: [set-slither-matrix, compile]
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,62 +11,70 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    style:
+    get-changed-files:
         runs-on: ubuntu-latest
-
         steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-                  cache: yarn
-
-            - name: Install dependencies
-              run: yarn
-
-            - name: Format code
-              run: yarn format
-    tests:
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                  node-version: "20"
-                  cache: yarn
-
-            - name: Install dependencies
-              run: yarn
-
+            - uses: actions/checkout@v4
             - name: Get changed files
               id: changed-files
               uses: tj-actions/changed-files@v44
               with:
-                  files: |
-                      packages/**/*.{sol,json,ts}
+                  files: packages/**/*.{sol,json,ts}
 
-            - if: steps.changed-files.outputs.any_changed == 'true'
-              name: Compile contracts
-              run: yarn compile
+    compile:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: yarn
 
-            - if: steps.changed-files.outputs.any_changed == 'true'
-              name: Test contracts
-              run: yarn test
+            - run: yarn
+            - run: yarn compile
 
-            - if: steps.changed-files.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+            - name: Upload compilation results
+              uses: actions/upload-artifacts@v4
+              with:
+                  name: all-artifacts
+                  path: packages/**/artifacts/**
+
+    style:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: yarn
+            - run: yarn
+            - run: yarn format
+    tests:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+                  cache: yarn
+            - uses: actions/download-artifact@v4
+              with:
+                  name: all-artifacts
+                  path: packages/
+            - run: yarn compile
+            - run: yarn
+            - run: yarn test
+
+            - if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               name: Coveralls
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
     set-slither-matrix:
+        if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -79,6 +87,7 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     slither:
+        if: ${{ needs.get-changed-files.outputs.any_changed = 'true' }}
         needs: set-slither-matrix
         runs-on: ubuntu-latest
         permissions:
@@ -93,8 +102,6 @@ jobs:
               with:
                   node-version: "20"
                   cache: yarn
-            - run: yarn
-            - run: yarn compile
 
             - name: Run slither
               uses: crytic/slither-action@v0.4.0
@@ -109,6 +116,7 @@ jobs:
               uses: github/codeql-action/upload-sarif@v3
               with:
                   sarif_file: ${{ steps.slither.outputs.sarif }}
+
             - name: Create/update checklist as PR comment
               uses: actions/github-script@v7
               if: github.even_name == 'pull_request'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - name: Run slither
-              uses: crytic/slityer-action@v0.4.0
+              uses: crytic/slither-action@v0.4.0
               id: slither
               with:
                   sarif: results.sarif

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,7 +153,8 @@ jobs:
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 
-            - name: Run slither
+            - if: contains(needs.get-changed-files.outputs.modified_files, ${{ matrix.dir }})
+              name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,7 @@ name: main
 
 on:
     push:
-        branches:
-            - main
+        branches: [main]
     pull_request:
 
 concurrency:
@@ -19,7 +18,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: 20
 
             - name: Output cache key
               id: cache-env
@@ -55,7 +54,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: 20
             - uses: actions/cache/restore@v4
               with:
                   path: node_modules
@@ -76,7 +75,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: 20
             - uses: actions/cache/restore@v4
               with:
                   path: node_modules
@@ -91,7 +90,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: 20
             - uses: actions/cache/restore@v4
               with:
                   path: node_modules
@@ -144,7 +143,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: "20"
+                  node-version: 20
             - uses: actions/cache/restore@v4
               with:
                   path: node_modules
@@ -153,19 +152,20 @@ jobs:
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 
-            - if: contains(needs.get-changed-files.outputs.modified_files, ${{ matrix.dir }})
+            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
               name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
               with:
                   ignore-compile: true
-                  node-version: "20"
+                  node-version: 20
                   fail-on: none
                   sarif: results.sarif
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
 
-            - name: Upload SARIF files
+            - if: contains(needs.get-changed-files.outputs.modified_files, matrix.dir)
+              name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:
                   sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node_version: "20"
+                  node-version: "20"
 
             - name: Run slither
               uses: crytic/slither-action@v0.4.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,29 +66,28 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-    gen-slither-matrix:
+    set-slither-matrix:
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.set-matrix.outputs.matrix }}
         steps:
             - uses: actions/checkout@v4
-            - name: get list of packages
+            - name: set-matrix
+              id: get-dirs
               run: |
-                  dirs=$(ls -1 packages)
-                  dirs_json=$(printf '%s\n' "$dirs" | jq -R . | jq -s .)
-                  echo "$dirs_json" >> $GITHUB_ENV
-            - name: set matrix
-              run: echo "::set-output name=matrix::${{ env.dirs_json }}"
+                matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
+                echo "$matrix"
+                echo "matrix" >> $GITHUB_OUTPUT
 
     slither:
-        needs: gen-slither-matrix
+        needs: set-slither-matrix
         runs-on: ubuntu-latest
         permissions:
             contents: read
             security-events: write
         strategy:
             matrix:
-                dir: ${{ fromJson(needs.gen-slither.matrix.outputs.matrix) }}
+                dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
             - name: Run slither

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
 
     slither:
         if: ${{ needs.get-changed-files.outputs.any_changed == 'true' }}
-        needs: [set-slither-matrix, compile]
+        needs: [set-slither-matrix, deps]
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -135,19 +135,35 @@ jobs:
                 dir: ${{ fromJson(needs.set-slither-matrix.outputs.matrix) }}
         steps:
             - uses: actions/checkout@v4
+
+            # FIXME this does not work as a way to restore compilation results for slither job but it does for the compile job ??
+            #- uses: actions/download-artifact@v4
+            #  with:
+            #      name: all-artifacts
+            #      path: packages/
+
             - uses: actions/setup-node@v4
               with:
                   node-version: "20"
+            - uses: actions/cache/restore@v4
+              with:
+                  path: node_modules
+                  key: ${{ needs.deps.outputs.cache-key }}
+            - run: |
+                  workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
+                  yarn workspace "$workspace" run compile
 
             - name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
               with:
                   ignore-compile: true
+                  node-version: "20"
                   fail-on: none
                   sarif: results.sarif
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
+
             - name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "bugs": "https://github.com/privacy-scaling-explorations/zk-kit.solidity/issues",
     "private": true,
     "scripts": {
-        "compile": "yarn workspaces foreach -A run compile",
-        "test": "yarn workspaces foreach -A run test:coverage",
+        "compile": "yarn workspaces foreach -Ap run compile",
+        "test": "yarn workspaces foreach -Ap run test:coverage",
         "version:bump": "yarn workspace @zk-kit/${0}.sol version ${1} && yarn remove:stable-version-field ${0} && NO_HOOK=1 git commit -am \"chore(${0}): v${1}\" && git tag ${0}.sol-v${1}",
         "version:publish": "yarn workspaces foreach -A --no-private npm publish --tolerate-republish --access public",
         "version:release": "changelogithub",


### PR DESCRIPTION
Integrate [slither via its GH action](https://github.com/marketplace/actions/slither-action) into the [`main.yml`](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/.github/workflows/main.yml) workflow:
- write a comment in the PR informing the results will be available in the repo's security section
- upload [SARIF](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning)  report to GH  (code scanning support)
- worklfow optimizations (sorry, this should have deserved its own PR ^^)
  - build deps in parallel and share node_modules between jobs
  - tests and slither jobs run in parallel
  - tests will only run for the impacted packages
  -  slither will only run for the impacted packages
  - compilation happens in a parallel job and the compilation results are shared with the other jobs using the [actions/upload-artifact](https://github.com/actions/upload-artifact) and [actions/download-artifact](https://github.com/actions/download-artifact)
  ![image](https://github.com/privacy-scaling-explorations/zk-kit.solidity/assets/38692952/12b65d6f-a359-411f-a339-1a9a377d2195)
  ![image](https://github.com/privacy-scaling-explorations/zk-kit.solidity/assets/38692952/cddf5cc9-b7ae-4f4a-bcc6-1d4942232c65)




Closes #7 ?

## Notes
As this PR does not change any files that trigger the slither workflow, I tested it in another branch, see https://github.com/privacy-scaling-explorations/zk-kit.solidity/pull/9
