### PR TITLE
Modify `Excubiae` framework design improve reuse of deployed specific `Excubia` contracts

### DIFF
--- a/packages/excubiae/contracts/Excubia.sol
+++ b/packages/excubiae/contracts/Excubia.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity >=0.8.0;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IExcubia} from "./IExcubia.sol";
 
 /// @title Excubia.
 /// @notice Abstract base contract which can be extended to implement a specific excubia.
-/// @dev Inherit from this contract and implement the `_check` method to define
-/// the custom gatekeeping logic.
+/// @dev Inherit from this contract and implement the `_pass` & `_check` methods to define
+/// your custom gatekeeping logic.
 abstract contract Excubia is IExcubia, Ownable(msg.sender) {
     /// @notice The excubia-protected contract address.
-    /// @dev The gate can be any contract address that requires a prior `_check`.
+    /// @dev The gate can be any contract address that requires a prior check to enable logic.
     /// For example, the gate is a Semaphore group that requires the passerby
     /// to meet certain criteria before joining.
     address public gate;
@@ -27,18 +27,34 @@ abstract contract Excubia is IExcubia, Ownable(msg.sender) {
         if (gate != address(0)) revert GateAlreadySet();
 
         gate = _gate;
+
+        emit GateSet(_gate);
     }
 
     /// @inheritdoc IExcubia
-    function pass(address passerby, bytes calldata data) public virtual onlyGate {
+    function pass(address passerby, bytes calldata data) external onlyGate {
+        _pass(passerby, data);
+    }
+
+    /// @inheritdoc IExcubia
+    function check(address passerby, bytes calldata data) external view returns (bool) {
+        return _check(passerby, data);
+    }
+
+    /// @notice Internal function to enforce the custom gate passing logic.
+    /// @dev Calls the `_check` internal logic and emits the relative event if successful.
+    /// @param passerby The address of the entity attempting to pass the gate.
+    /// @param data Additional data required for the check (e.g., encoded token identifier).
+    function _pass(address passerby, bytes calldata data) internal virtual {
         if (!_check(passerby, data)) revert AccessDenied();
 
         emit GatePassed(passerby, gate);
     }
 
-    /// @dev Abstract internal function to be implemented with custom logic to check if the passerby can pass the gate.
+    /// @notice Internal function to define the custom gate protection logic.
+    /// @dev Custom logic to determine if the passerby can pass the gate.
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data that may be required for the check.
-    /// @return True if the passerby passes the check, false otherwise.
-    function _check(address passerby, bytes calldata data) internal virtual returns (bool);
+    /// @return passed True if the passerby passes the check, false otherwise.
+    function _check(address passerby, bytes calldata data) internal view virtual returns (bool passed) {}
 }

--- a/packages/excubiae/contracts/Excubia.sol
+++ b/packages/excubiae/contracts/Excubia.sol
@@ -55,6 +55,5 @@ abstract contract Excubia is IExcubia, Ownable(msg.sender) {
     /// @dev Custom logic to determine if the passerby can pass the gate.
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data that may be required for the check.
-    /// @return passed True if the passerby passes the check, false otherwise.
-    function _check(address passerby, bytes calldata data) internal view virtual returns (bool passed) {}
+    function _check(address passerby, bytes calldata data) internal view virtual returns (bool) {}
 }

--- a/packages/excubiae/contracts/IExcubia.sol
+++ b/packages/excubiae/contracts/IExcubia.sol
@@ -1,13 +1,17 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity >=0.8.0;
 
 /// @title IExcubia.
 /// @notice Excubia contract interface.
 interface IExcubia {
-    /// @notice Event emitted when someone passes the `_check` method.
+    /// @notice Event emitted when someone passes the gate check.
     /// @param passerby The address of those who have successfully passed the check.
     /// @param gate The address of the excubia-protected contract address.
     event GatePassed(address indexed passerby, address indexed gate);
+
+    /// @notice Event emitted when the gate address is set.
+    /// @param gate The address of the contract set as the gate.
+    event GateSet(address indexed gate);
 
     /// @notice Error thrown when an address equal to zero is given.
     error ZeroAddress();
@@ -29,9 +33,15 @@ interface IExcubia {
     /// @param _gate The address of the contract to be set as the gate.
     function setGate(address _gate) external;
 
-    /// @notice Initiates the excubia's check and triggers the associated action if the check is passed.
-    /// @dev Calls `_check` to handle the logic of checking for passing the gate.
+    /// @notice Enforces the custom gate passing logic.
+    /// @dev Must call the `check` to handle the logic of checking passerby for specific gate.
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data required for the check (e.g., encoded token identifier).
     function pass(address passerby, bytes calldata data) external;
+
+    /// @dev Defines the custom gate protection logic.
+    /// @param passerby The address of the entity attempting to pass the gate.
+    /// @param data Additional data that may be required for the check.
+    /// @return True if the passerby passes the check, false otherwise.
+    function check(address passerby, bytes calldata data) external view returns (bool);
 }

--- a/packages/excubiae/contracts/README.md
+++ b/packages/excubiae/contracts/README.md
@@ -57,23 +57,28 @@ yarn add @zk-kit/excubiae
 To build your own Excubia:
 
 1. Inherit from the [Excubia](./Excubia.sol) abstract contract that conforms to the [IExcubia](./IExcubia.sol) interface.
-2. Implement the `_check()` method to define your own gatekeeping logic and to prevent unwanted access (sybils, double checks).
+2. Implement the `_check()` and `_pass()` methods logic defining your own checks to prevent unwanted access (sybils, double checks).
 
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity >=0.8.0;
 
 import { Excubia } from "excubiae/contracts/Excubia.sol";
 
 contract MyExcubia is Excubia {
     // ...
 
-    function _check(address passerby, bytes calldata data) internal override returns (bool) {
-        // Implement custom access control logic here.
+    function _pass(address passerby, bytes calldata data) internal override {
         // Implement your logic to prevent unwanted access here.
+    }
+
+    function _check(address passerby, bytes calldata data) internal view override returns (bool) {
+        // Implement custom access control logic here.
 
         return true;
     }
+
+    // ...
 }
 ```
 

--- a/packages/excubiae/contracts/README.md
+++ b/packages/excubiae/contracts/README.md
@@ -57,7 +57,7 @@ yarn add @zk-kit/excubiae
 To build your own Excubia:
 
 1. Inherit from the [Excubia](./Excubia.sol) abstract contract that conforms to the [IExcubia](./IExcubia.sol) interface.
-2. Implement the `_check()` and `_pass()` methods logic defining your own checks to prevent unwanted access (sybils, double checks).
+2. Implement the `_check()` and `_pass()` methods logic defining your own checks to prevent unwanted access as sybils or avoid to pass the gate twice with the same data / identity.
 
 ```solidity
 // SPDX-License-Identifier: MIT

--- a/packages/excubiae/contracts/extensions/EASExcubia.sol
+++ b/packages/excubiae/contracts/extensions/EASExcubia.sol
@@ -19,7 +19,7 @@ contract EASExcubia is Excubia {
     address public immutable ATTESTER;
 
     /// @notice Mapping to track which attestations have been registered by the contract to
-    /// avoid double checks with the same attestation.
+    /// avoid pass the gate twice with the same attestation.
     mapping(bytes32 => bool) public registeredAttestations;
 
     /// @notice Error thrown when the attestation has been already used to pass the gate.
@@ -50,7 +50,7 @@ contract EASExcubia is Excubia {
     }
 
     /// @notice Internal function to handle the passing logic with check.
-    /// @dev Calls the parent `_pass` function and registers the attestation to avoid double checks.
+    /// @dev Calls the parent `_pass` function and registers the attestation to avoid pass the gate twice.
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data required for the check (e.g., encoded attestation ID).
     function _pass(address passerby, bytes calldata data) internal override {
@@ -58,7 +58,7 @@ contract EASExcubia is Excubia {
 
         bytes32 attestationId = abi.decode(data, (bytes32));
 
-        // Avoiding double check of the same attestation.
+        // Avoiding passing the gate twice using the same attestation.
         if (registeredAttestations[attestationId]) revert AlreadyRegistered();
 
         registeredAttestations[attestationId] = true;

--- a/packages/excubiae/contracts/test/MockEAS.sol
+++ b/packages/excubiae/contracts/test/MockEAS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
 /* solhint-disable max-line-length */
 import {IEAS, ISchemaRegistry, AttestationRequest, MultiAttestationRequest, DelegatedAttestationRequest, MultiDelegatedAttestationRequest, DelegatedRevocationRequest, RevocationRequest, MultiRevocationRequest, MultiDelegatedRevocationRequest} from "@ethereum-attestation-service/eas-contracts/contracts/IEAS.sol";

--- a/packages/excubiae/hardhat.config.ts
+++ b/packages/excubiae/hardhat.config.ts
@@ -3,7 +3,7 @@ import { HardhatUserConfig } from "hardhat/config"
 
 const hardhatConfig: HardhatUserConfig = {
     solidity: {
-        version: "0.8.23",
+        version: "0.8.20",
         settings: {
             optimizer: {
                 enabled: true


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
The actual design of Excubiae centralises the definition of the custom access control and prevention of unwanted access logic within the `_check()` method. Consequently, the developer is required to extend the Excubia contract and implement the logic for the `_check()` method only. 

This design has several advantages, including reduced gas cost and the ease of creating one's own custom contract (one method override). However, this approach presents a significant challenge when attempting to reuse the same logic defined in an Excubia within a different contract. Indeed, interfacing with an Excubia and extending or reusing the `_check()`, would result in a tentative update to the execution of both logics (custom access control and prevention of unwanted access). 

This is a problematic scenario because it is undesirable for an external Excubia to have the ability to modify the status directly and thereby render any records of users who have already passed invalid. Furthermore, it would be highly limiting from the perspective of aggregating multiple Excubias. 

With regard to this latter point, if it were not possible to reuse the aforementioned `_check()`, it would be necessary to deploy the precise same Excubia, which would result in increased costs and the replication of on-chain logic.

In consequence, this PR introduces a novel design comprising:
- an internal method, `_check()`, which will exclusively address custom access control logic; and
- an internal method, `_pass()`, which will exclusively prevent unwanted access.

In addition, there will be two external methods (`check()` and `pass()`), which can be called externally to ascertain whether the custom access control logic is eligible to be passed (without requesting to pass the gate) or to attempt to pass the gate.

This approach allows for the aggregation of multiple Excubia instances and the invocation of the public interface, represented by the `check()` function. Based on the outcomes of these checks, the implementation of the logic preventing unwanted access can be initiated in the `_pass()` function. This will result in a change to the state of the aggregation contract, rather than that of the individual aggregates. This approach allows for the aggregation of the aggregation contract itself, representing a significant advancement in the composability of Excubia.

The following are the disadvantages for the new design:
- Limited increased gas costs: the deployment of `EASExcubia` incurs an additional expense of approximately 31k gas, while the execution of `setGate()` and `pass()` requires a mere 1k and 200 gas, respectively. This is a great trade-off since you deploy once and you do not need to duplicate deploys of Excubia anymore.
- The necessity for developers to incorporate custom code for both `_pass()` and `_check()` methods.
- The potential for the inclusion of redundant, low-cost code in both methods.

## Other information
Additional modifications include the introduction of a 'GateSet' event to the 'setGate()' method, the adjustment of the supported Solidity version to 0.8.20, enhancements to the comments and interfaces, and the incorporation of missing tests to achieve comprehensive coverage.

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn compile` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
