### PR TITLE
Porting MACI's `FreeForAll` and `SignUpToken` gatekeepers

### DIFF
--- a/packages/excubiae/contracts/IExcubia.sol
+++ b/packages/excubiae/contracts/IExcubia.sol
@@ -29,7 +29,7 @@ interface IExcubia {
     error AccessDenied();
 
     /// @notice Error thrown when the passerby has already passed the gate.
-    error AlreadyRegistered();
+    error AlreadyPassed();
 
     /// @notice Sets the gate address.
     /// @dev Only the owner can set the destination gate address.

--- a/packages/excubiae/contracts/IExcubia.sol
+++ b/packages/excubiae/contracts/IExcubia.sol
@@ -28,6 +28,9 @@ interface IExcubia {
     /// @notice Error thrown when access is denied by the excubia.
     error AccessDenied();
 
+    /// @notice Error thrown when the passerby has already passed the gate.
+    error AlreadyRegistered();
+
     /// @notice Sets the gate address.
     /// @dev Only the owner can set the destination gate address.
     /// @param _gate The address of the contract to be set as the gate.

--- a/packages/excubiae/contracts/extensions/EASExcubia.sol
+++ b/packages/excubiae/contracts/extensions/EASExcubia.sol
@@ -22,9 +22,6 @@ contract EASExcubia is Excubia {
     /// avoid double checks with the same attestation.
     mapping(bytes32 => bool) public registeredAttestations;
 
-    /// @notice Error thrown when the attestation has been already used to pass the gate.
-    error AlreadyRegistered();
-
     /// @notice Error thrown when the attestation does not match the designed schema.
     error UnexpectedSchema();
 

--- a/packages/excubiae/contracts/extensions/EASExcubia.sol
+++ b/packages/excubiae/contracts/extensions/EASExcubia.sol
@@ -67,6 +67,8 @@ contract EASExcubia is Excubia {
     /// @param data Additional data required for the check (e.g., encoded attestation ID).
     /// @return True if the attestation is valid and the passerby passes the check, false otherwise.
     function _check(address passerby, bytes calldata data) internal view override returns (bool) {
+        super._check(passerby, data);
+
         bytes32 attestationId = abi.decode(data, (bytes32));
 
         Attestation memory attestation = EAS.getAttestation(attestationId);

--- a/packages/excubiae/contracts/extensions/EASExcubia.sol
+++ b/packages/excubiae/contracts/extensions/EASExcubia.sol
@@ -51,12 +51,12 @@ contract EASExcubia is Excubia {
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data required for the check (e.g., encoded attestation ID).
     function _pass(address passerby, bytes calldata data) internal override {
-        super._pass(passerby, data);
-
         bytes32 attestationId = abi.decode(data, (bytes32));
 
         // Avoiding passing the gate twice using the same attestation.
-        if (registeredAttestations[attestationId]) revert AlreadyRegistered();
+        if (registeredAttestations[attestationId]) revert AlreadyPassed();
+
+        super._pass(passerby, data);
 
         registeredAttestations[attestationId] = true;
     }

--- a/packages/excubiae/contracts/extensions/ERC721Excubia.sol
+++ b/packages/excubiae/contracts/extensions/ERC721Excubia.sol
@@ -32,12 +32,12 @@ contract ERC721Excubia is Excubia {
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data required for the check (e.g., encoded token ID).
     function _pass(address passerby, bytes calldata data) internal override {
-        super._pass(passerby, data);
-
         uint256 tokenId = abi.decode(data, (uint256));
 
         // Avoiding passing the gate twice with the same token ID.
-        if (registeredTokenIds[tokenId]) revert AlreadyRegistered();
+        if (registeredTokenIds[tokenId]) revert AlreadyPassed();
+
+        super._pass(passerby, data);
 
         registeredTokenIds[tokenId] = true;
     }

--- a/packages/excubiae/contracts/extensions/ERC721Excubia.sol
+++ b/packages/excubiae/contracts/extensions/ERC721Excubia.sol
@@ -13,7 +13,7 @@ contract ERC721Excubia is Excubia {
     IERC721 public immutable NFT;
 
     /// @notice Mapping to track which token IDs have been registered by the contract to
-    /// avoid double checks with the same token ID.
+    /// avoid passing the gate twice with the same token ID.
     mapping(uint256 => bool) public registeredTokenIds;
 
     /// @notice Error thrown when the passerby is not the owner of the token.
@@ -28,7 +28,7 @@ contract ERC721Excubia is Excubia {
     }
 
     /// @notice Internal function to handle the passing logic with check.
-    /// @dev Calls the parent `_pass` function and registers the NFT ID to avoid double checks.
+    /// @dev Calls the parent `_pass` function and registers the NFT ID to avoid passing the gate twice.
     /// @param passerby The address of the entity attempting to pass the gate.
     /// @param data Additional data required for the check (e.g., encoded token ID).
     function _pass(address passerby, bytes calldata data) internal override {
@@ -36,7 +36,7 @@ contract ERC721Excubia is Excubia {
 
         uint256 tokenId = abi.decode(data, (uint256));
 
-        // Avoiding double check of the same token ID.
+        // Avoiding passing the gate twice with the same token ID.
         if (registeredTokenIds[tokenId]) revert AlreadyRegistered();
 
         registeredTokenIds[tokenId] = true;

--- a/packages/excubiae/contracts/extensions/ERC721Excubia.sol
+++ b/packages/excubiae/contracts/extensions/ERC721Excubia.sol
@@ -21,7 +21,7 @@ contract ERC721Excubia is Excubia {
 
     /// @notice Constructor to initialize with target ERC721 contract.
     /// @param _erc721 The address of the ERC721 contract.
-    constructor(address _erc721) payable {
+    constructor(address _erc721) {
         if (_erc721 == address(0)) revert ZeroAddress();
 
         NFT = IERC721(_erc721);

--- a/packages/excubiae/contracts/extensions/ERC721Excubia.sol
+++ b/packages/excubiae/contracts/extensions/ERC721Excubia.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {Excubia} from "../Excubia.sol";
+import {IERC721} from "@openzeppelin/contracts/interfaces/IERC721.sol";
+
+/// @title ERC721 Excubia Contract.
+/// @notice This contract extends the Excubia contract to integrate with an ERC721 token.
+/// This contract checks the ownership of an ERC721 token to permit access through the gate.
+/// @dev The contract refers to a contract implementing the ERC721 standard to admit the owner of the token.
+contract ERC721Excubia is Excubia {
+    /// @notice The ERC721 token contract interface.
+    IERC721 public immutable NFT;
+
+    /// @notice Mapping to track which token IDs have been registered by the contract to
+    /// avoid double checks with the same token ID.
+    mapping(uint256 => bool) public registeredTokenIds;
+
+    /// @notice Error thrown when the passerby is not the owner of the token.
+    error UnexpectedTokenOwner();
+
+    /// @notice Constructor to initialize with target ERC721 contract.
+    /// @param _erc721 The address of the ERC721 contract.
+    constructor(address _erc721) payable {
+        if (_erc721 == address(0)) revert ZeroAddress();
+
+        NFT = IERC721(_erc721);
+    }
+
+    /// @notice Internal function to handle the passing logic with check.
+    /// @dev Calls the parent `_pass` function and registers the NFT ID to avoid double checks.
+    /// @param passerby The address of the entity attempting to pass the gate.
+    /// @param data Additional data required for the check (e.g., encoded token ID).
+    function _pass(address passerby, bytes calldata data) internal override {
+        super._pass(passerby, data);
+
+        uint256 tokenId = abi.decode(data, (uint256));
+
+        // Avoiding double check of the same token ID.
+        if (registeredTokenIds[tokenId]) revert AlreadyRegistered();
+
+        registeredTokenIds[tokenId] = true;
+    }
+
+    /// @notice Internal function to handle the gate protection (token ownership check) logic.
+    /// @dev Checks if the passerby is the owner of the token.
+    /// @param passerby The address of the entity attempting to pass the gate.
+    /// @param data Additional data required for the check (e.g., encoded token ID).
+    /// @return True if the passerby owns the token, false otherwise.
+    function _check(address passerby, bytes calldata data) internal view override returns (bool) {
+        uint256 tokenId = abi.decode(data, (uint256));
+
+        // Check if the user owns the token.
+        if (!(NFT.ownerOf(tokenId) == passerby)) revert UnexpectedTokenOwner();
+
+        return true;
+    }
+}

--- a/packages/excubiae/contracts/extensions/ERC721Excubia.sol
+++ b/packages/excubiae/contracts/extensions/ERC721Excubia.sol
@@ -48,6 +48,8 @@ contract ERC721Excubia is Excubia {
     /// @param data Additional data required for the check (e.g., encoded token ID).
     /// @return True if the passerby owns the token, false otherwise.
     function _check(address passerby, bytes calldata data) internal view override returns (bool) {
+        super._check(passerby, data);
+
         uint256 tokenId = abi.decode(data, (uint256));
 
         // Check if the user owns the token.

--- a/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
+++ b/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
@@ -19,16 +19,18 @@ contract FreeForAllExcubia is Excubia {
     /// @param passerby The address of the entity passing the gate.
     /// @param data Additional data required for the pass (not used in this implementation).
     function _pass(address passerby, bytes calldata data) internal override {
-        super._pass(passerby, data);
-
         // Avoiding passing the gate twice with the same address.
-        if (registeredPassersby[passerby]) revert AlreadyRegistered();
+        if (registeredPassersby[passerby]) revert AlreadyPassed();
+
+        super._pass(passerby, data);
 
         registeredPassersby[passerby] = true;
     }
 
     /// @notice Internal function to handle the gate protection logic.
     /// @dev This function always returns true, signaling that any passerby is able to pass the gate.
+    /// @param passerby The address of the entity attempting to pass the gate.
+    /// @param data Additional data required for the check (e.g., encoded attestation ID).
     /// @return True, allowing any passerby to pass the gate.
     function _check(address passerby, bytes calldata data) internal view override returns (bool) {
         super._check(passerby, data);

--- a/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
+++ b/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {Excubia} from "../Excubia.sol";
+
+/// @title FreeForAll Excubia Contract.
+/// @notice This contract extends the Excubia contract to allow free access through the gate.
+/// This contract does not perform any checks and allows any passerby to pass the gate.
+/// @dev The contract overrides the `_check` function to always return true.
+contract FreeForAllExcubia is Excubia {
+    /// @notice Constructor for the FreeForAllExcubia contract.
+    constructor() {}
+
+    /// @notice Mapping to track already registered passersby.
+    mapping(bytes32 => bool) public registeredPassersby;
+
+    /// @notice Internal function to handle the gate passing logic.
+    /// @dev This function calls the parent `_pass` function and then tracks the passerby.
+    /// @param passerby The address of the entity passing the gate.
+    /// @param data Additional data required for the pass (not used in this implementation).
+    function _pass(address passerby, bytes calldata data) internal override {
+        super._pass(passerby, data);
+
+        bytes32 encodedPasserby = keccak256(abi.encodePacked(passerby));
+
+        // Avoiding double check of the same passerby.
+        if (registeredPassersby[encodedPasserby]) revert AlreadyRegistered();
+
+        registeredPassersby[encodedPasserby] = true;
+    }
+
+    /// @notice Internal function to handle the gate protection logic.
+    /// @dev This function always returns true, signaling that any passerby is able to pass the gate.
+    /// @return True, allowing any passerby to pass the gate.
+    function _check(address /*passerby*/, bytes calldata /*data*/) internal pure override returns (bool) {
+        return true; /// @todo check if optional.
+    }
+}

--- a/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
+++ b/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
@@ -12,7 +12,7 @@ contract FreeForAllExcubia is Excubia {
     constructor() {}
 
     /// @notice Mapping to track already registered passersby.
-    mapping(bytes32 => bool) public registeredPassersby;
+    mapping(address => bool) public registeredPassersby;
 
     /// @notice Internal function to handle the gate passing logic.
     /// @dev This function calls the parent `_pass` function and then tracks the passerby.
@@ -21,18 +21,18 @@ contract FreeForAllExcubia is Excubia {
     function _pass(address passerby, bytes calldata data) internal override {
         super._pass(passerby, data);
 
-        bytes32 encodedPasserby = keccak256(abi.encodePacked(passerby));
-
         // Avoiding double check of the same passerby.
-        if (registeredPassersby[encodedPasserby]) revert AlreadyRegistered();
+        if (registeredPassersby[passerby]) revert AlreadyRegistered();
 
-        registeredPassersby[encodedPasserby] = true;
+        registeredPassersby[passerby] = true;
     }
 
     /// @notice Internal function to handle the gate protection logic.
     /// @dev This function always returns true, signaling that any passerby is able to pass the gate.
     /// @return True, allowing any passerby to pass the gate.
-    function _check(address /*passerby*/, bytes calldata /*data*/) internal pure override returns (bool) {
-        return true; /// @todo check if optional.
+    function _check(address passerby, bytes calldata data) internal view override returns (bool) {
+        super._check(passerby, data);
+
+        return true;
     }
 }

--- a/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
+++ b/packages/excubiae/contracts/extensions/FreeForAllExcubia.sol
@@ -21,7 +21,7 @@ contract FreeForAllExcubia is Excubia {
     function _pass(address passerby, bytes calldata data) internal override {
         super._pass(passerby, data);
 
-        // Avoiding double check of the same passerby.
+        // Avoiding passing the gate twice with the same address.
         if (registeredPassersby[passerby]) revert AlreadyRegistered();
 
         registeredPassersby[passerby] = true;

--- a/packages/excubiae/contracts/test/MockEAS.sol
+++ b/packages/excubiae/contracts/test/MockEAS.sol
@@ -25,12 +25,12 @@ contract MockEAS is IEAS {
         getSchemaRegistry = ISchemaRegistry(address(1));
 
         Attestation memory valid = Attestation({
-            uid: bytes32("0x01"),
+            uid: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             schema: _schema,
             time: 0,
             expirationTime: 0,
             revocationTime: 0,
-            refUID: bytes32("0x01"),
+            refUID: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             recipient: _recipient,
             attester: _attester,
             revocable: true,
@@ -38,12 +38,12 @@ contract MockEAS is IEAS {
         });
 
         Attestation memory revoked = Attestation({
-            uid: bytes32("0x02"),
+            uid: bytes32(hex"0200000000000000000000000000000000000000000000000000000000000000"),
             schema: _schema,
             time: 0,
             expirationTime: 0,
             revocationTime: 1,
-            refUID: bytes32("0x01"),
+            refUID: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             recipient: _recipient,
             attester: _attester,
             revocable: true,
@@ -51,12 +51,12 @@ contract MockEAS is IEAS {
         });
 
         Attestation memory invalidSchema = Attestation({
-            uid: bytes32("0x03"),
-            schema: bytes32("0x01"),
+            uid: bytes32(hex"0300000000000000000000000000000000000000000000000000000000000000"),
+            schema: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             time: 0,
             expirationTime: 0,
             revocationTime: 0,
-            refUID: bytes32("0x01"),
+            refUID: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             recipient: _recipient,
             attester: _attester,
             revocable: true,
@@ -64,12 +64,12 @@ contract MockEAS is IEAS {
         });
 
         Attestation memory invalidRecipient = Attestation({
-            uid: bytes32("0x04"),
+            uid: bytes32(hex"0400000000000000000000000000000000000000000000000000000000000000"),
             schema: _schema,
             time: 0,
             expirationTime: 0,
             revocationTime: 0,
-            refUID: bytes32("0x01"),
+            refUID: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             recipient: address(1),
             attester: _attester,
             revocable: true,
@@ -77,23 +77,29 @@ contract MockEAS is IEAS {
         });
 
         Attestation memory invalidAttester = Attestation({
-            uid: bytes32("0x05"),
+            uid: bytes32(hex"0500000000000000000000000000000000000000000000000000000000000000"),
             schema: _schema,
             time: 0,
             expirationTime: 0,
             revocationTime: 0,
-            refUID: bytes32("0x000000000000000000000000000001"),
+            refUID: bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000"),
             recipient: _recipient,
             attester: address(1),
             revocable: true,
             data: bytes("")
         });
 
-        mockedAttestations[bytes32("0x01")] = valid;
-        mockedAttestations[bytes32("0x02")] = revoked;
-        mockedAttestations[bytes32("0x03")] = invalidSchema;
-        mockedAttestations[bytes32("0x04")] = invalidRecipient;
-        mockedAttestations[bytes32("0x05")] = invalidAttester;
+        mockedAttestations[bytes32(hex"0100000000000000000000000000000000000000000000000000000000000000")] = valid;
+        mockedAttestations[bytes32(hex"0200000000000000000000000000000000000000000000000000000000000000")] = revoked;
+        mockedAttestations[
+            bytes32(hex"0300000000000000000000000000000000000000000000000000000000000000")
+        ] = invalidSchema;
+        mockedAttestations[
+            bytes32(hex"0400000000000000000000000000000000000000000000000000000000000000")
+        ] = invalidRecipient;
+        mockedAttestations[
+            bytes32(hex"0500000000000000000000000000000000000000000000000000000000000000")
+        ] = invalidAttester;
     }
 
     /// @notice Retrieves a mocked attestation by its unique identifier.

--- a/packages/excubiae/contracts/test/MockERC721.sol
+++ b/packages/excubiae/contracts/test/MockERC721.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Mock ERC721 Token Contract.
+/// @notice This contract is a mock implementation of the ERC721 standard for testing purposes.
+/// @dev It simulates the behavior of a real ERC721 contract by providing basic minting functionality.
+contract MockERC721 is ERC721, Ownable(msg.sender) {
+    /// @notice A counter to keep track of the token IDs.
+    uint256 private _tokenIdCounter;
+
+    /// @notice Constructor to initialize the mock contract with a name and symbol.
+    constructor() payable ERC721("MockERC721Token", "MockERC721Token") {}
+
+    /// @notice Mints a new token and assigns it to the specified recipient.
+    /// @param recipient The address that will receive the minted token.
+    function mintAndGiveToken(address recipient) public onlyOwner {
+        _safeMint(recipient, _tokenIdCounter++);
+    }
+}

--- a/packages/excubiae/test/EASExcubia.test.ts
+++ b/packages/excubiae/test/EASExcubia.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { ethers } from "hardhat"
-import { Signer, ZeroAddress } from "ethers"
+import { AbiCoder, Signer, ZeroAddress, toBeHex, zeroPadBytes } from "ethers"
 import { EASExcubia, EASExcubia__factory, MockEAS, MockEAS__factory } from "../typechain-types"
 
 describe("EASExcubia", function () {
@@ -18,11 +18,11 @@ describe("EASExcubia", function () {
     let mockEASAddress: string
 
     const schemaId = "0xfdcfdad2dbe7489e0ce56b260348b7f14e8365a8a325aef9834818c00d46b31b"
-    const validAttestationId = ethers.encodeBytes32String("0x01")
-    const revokedAttestationId = ethers.encodeBytes32String("0x02")
-    const invalidSchemaAttestationId = ethers.encodeBytes32String("0x03")
-    const invalidRecipientAttestationId = ethers.encodeBytes32String("0x04")
-    const invalidAttesterAttestationId = ethers.encodeBytes32String("0x05")
+    const validAttestationId = AbiCoder.defaultAbiCoder().encode(["bytes32"], [zeroPadBytes(toBeHex(1), 32)])
+    const revokedAttestationId = AbiCoder.defaultAbiCoder().encode(["bytes32"], [zeroPadBytes(toBeHex(2), 32)])
+    const invalidSchemaAttestationId = AbiCoder.defaultAbiCoder().encode(["bytes32"], [zeroPadBytes(toBeHex(3), 32)])
+    const invalidRecipientAttestationId = AbiCoder.defaultAbiCoder().encode(["bytes32"], [zeroPadBytes(toBeHex(4), 32)])
+    const invalidAttesterAttestationId = AbiCoder.defaultAbiCoder().encode(["bytes32"], [zeroPadBytes(toBeHex(5), 32)])
 
     before(async function () {
         ;[signer, gate] = await ethers.getSigners()
@@ -46,11 +46,17 @@ describe("EASExcubia", function () {
             expect(mockEAS).to.not.eq(undefined)
         })
 
-        it("Should fail to deploy EASExcubia when attester parameter is not valid", async () => {
-            await expect(EASExcubiaContract.deploy(signerAddress, ZeroAddress, schemaId)).to.be.revertedWithCustomError(
+        it("Should fail to deploy EASExcubia when eas parameter is not valid", async () => {
+            await expect(EASExcubiaContract.deploy(ZeroAddress, ZeroAddress, schemaId)).to.be.revertedWithCustomError(
                 easExcubia,
                 "ZeroAddress"
             )
+        })
+
+        it("Should fail to deploy EASExcubia when attester parameter is not valid", async () => {
+            await expect(
+                EASExcubiaContract.deploy(await easExcubia.getAddress(), ZeroAddress, schemaId)
+            ).to.be.revertedWithCustomError(easExcubia, "ZeroAddress")
         })
     })
 

--- a/packages/excubiae/test/EASExcubia.test.ts
+++ b/packages/excubiae/test/EASExcubia.test.ts
@@ -37,7 +37,7 @@ describe("EASExcubia", function () {
         easExcubia = await EASExcubiaContract.deploy(mockEASAddress, signerAddress, schemaId)
     })
 
-    describe("Deployment", function () {
+    describe("constructor()", function () {
         it("Should deploy the EASExcubia contract correctly", async function () {
             expect(easExcubia).to.not.eq(undefined)
         })
@@ -54,135 +54,132 @@ describe("EASExcubia", function () {
         })
     })
 
-    describe("EASExcubia", function () {
-        describe("setGate()", function () {
-            it("should fail to set the gate when the caller is not the owner", async () => {
-                const [, notOwnerSigner] = await ethers.getSigners()
+    describe("setGate()", function () {
+        it("should fail to set the gate when the caller is not the owner", async () => {
+            const [, notOwnerSigner] = await ethers.getSigners()
 
-                await expect(easExcubia.connect(notOwnerSigner).setGate(gateAddress)).to.be.revertedWithCustomError(
-                    easExcubia,
-                    "OwnableUnauthorizedAccount"
-                )
-            })
-
-            it("should fail to set the gate when the gate address is zero", async () => {
-                await expect(easExcubia.setGate(ZeroAddress)).to.be.revertedWithCustomError(easExcubia, "ZeroAddress")
-            })
-
-            it("Should set the gate contract address correctly", async function () {
-                const tx = await easExcubia.setGate(gateAddress)
-                const receipt = await tx.wait()
-                const event = EASExcubiaContract.interface.parseLog(
-                    receipt?.logs[0] as unknown as { topics: string[]; data: string }
-                ) as unknown as {
-                    args: {
-                        gate: string
-                    }
-                }
-
-                expect(receipt?.status).to.eq(1)
-                expect(event.args.gate).to.eq(gateAddress)
-                expect(await easExcubia.gate()).to.eq(gateAddress)
-            })
-
-            it("Should fail to set the gate if already set", async function () {
-                await expect(easExcubia.setGate(gateAddress)).to.be.revertedWithCustomError(
-                    easExcubia,
-                    "GateAlreadySet"
-                )
-            })
+            await expect(easExcubia.connect(notOwnerSigner).setGate(gateAddress)).to.be.revertedWithCustomError(
+                easExcubia,
+                "OwnableUnauthorizedAccount"
+            )
         })
 
-        describe("check()", function () {
-            it("should throw when the attestation is not owned by the correct recipient", async () => {
-                await expect(
-                    easExcubia.check(signerAddress, invalidRecipientAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "UnexpectedRecipient")
-            })
-
-            it("should throw when the attestation has been revoked", async () => {
-                await expect(easExcubia.check(signerAddress, revokedAttestationId)).to.be.revertedWithCustomError(
-                    easExcubia,
-                    "RevokedAttestation"
-                )
-            })
-
-            it("should throw when the attestation schema is not the one expected", async () => {
-                await expect(easExcubia.check(signerAddress, invalidSchemaAttestationId)).to.be.revertedWithCustomError(
-                    easExcubia,
-                    "UnexpectedSchema"
-                )
-            })
-
-            it("should throw when the attestation is not signed by the attestation owner", async () => {
-                await expect(
-                    easExcubia.check(signerAddress, invalidAttesterAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "UnexpectedAttester")
-            })
-
-            it("should pass the check", async () => {
-                const passed = await easExcubia.check(signerAddress, validAttestationId)
-
-                expect(passed).to.be.true
-                // check does NOT change the state of the contract (see pass()).
-                expect(await easExcubia.registeredAttestations(validAttestationId)).to.be.false
-            })
+        it("should fail to set the gate when the gate address is zero", async () => {
+            await expect(easExcubia.setGate(ZeroAddress)).to.be.revertedWithCustomError(easExcubia, "ZeroAddress")
         })
 
-        describe("pass()", function () {
-            it("should throw when the callee is not the gate", async () => {
-                await expect(
-                    easExcubia.connect(signer).pass(signerAddress, invalidRecipientAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "GateOnly")
-            })
-
-            it("should throw when the attestation is not owned by the correct recipient", async () => {
-                await expect(
-                    easExcubia.connect(gate).pass(signerAddress, invalidRecipientAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "UnexpectedRecipient")
-            })
-
-            it("should throw when the attestation has been revoked", async () => {
-                await expect(
-                    easExcubia.connect(gate).pass(signerAddress, revokedAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "RevokedAttestation")
-            })
-
-            it("should throw when the attestation schema is not the one expected", async () => {
-                await expect(
-                    easExcubia.connect(gate).pass(signerAddress, invalidSchemaAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "UnexpectedSchema")
-            })
-
-            it("should throw when the attestation is not signed by the attestation owner", async () => {
-                await expect(
-                    easExcubia.connect(gate).pass(signerAddress, invalidAttesterAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "UnexpectedAttester")
-            })
-
-            it("should pass the check", async () => {
-                const tx = await easExcubia.connect(gate).pass(signerAddress, validAttestationId)
-                const receipt = await tx.wait()
-                const event = EASExcubiaContract.interface.parseLog(
-                    receipt?.logs[0] as unknown as { topics: string[]; data: string }
-                ) as unknown as {
-                    args: {
-                        passerby: string
-                        gate: string
-                    }
+        it("Should set the gate contract address correctly", async function () {
+            const tx = await easExcubia.setGate(gateAddress)
+            const receipt = await tx.wait()
+            const event = EASExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    gate: string
                 }
+            }
 
-                expect(receipt?.status).to.eq(1)
-                expect(event.args.passerby).to.eq(signerAddress)
-                expect(event.args.gate).to.eq(gateAddress)
-                expect(await easExcubia.registeredAttestations(validAttestationId)).to.be.true
-            })
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await easExcubia.gate()).to.eq(gateAddress)
+        })
 
-            it("should prevent to pass twice", async () => {
-                await expect(
-                    easExcubia.connect(gate).pass(signerAddress, validAttestationId)
-                ).to.be.revertedWithCustomError(easExcubia, "AlreadyRegistered")
-            })
+        it("Should fail to set the gate if already set", async function () {
+            await expect(easExcubia.setGate(gateAddress)).to.be.revertedWithCustomError(easExcubia, "GateAlreadySet")
+        })
+    })
+
+    describe("check()", function () {
+        it("should throw when the attestation is not owned by the correct recipient", async () => {
+            await expect(easExcubia.check(signerAddress, invalidRecipientAttestationId)).to.be.revertedWithCustomError(
+                easExcubia,
+                "UnexpectedRecipient"
+            )
+        })
+
+        it("should throw when the attestation has been revoked", async () => {
+            await expect(easExcubia.check(signerAddress, revokedAttestationId)).to.be.revertedWithCustomError(
+                easExcubia,
+                "RevokedAttestation"
+            )
+        })
+
+        it("should throw when the attestation schema is not the one expected", async () => {
+            await expect(easExcubia.check(signerAddress, invalidSchemaAttestationId)).to.be.revertedWithCustomError(
+                easExcubia,
+                "UnexpectedSchema"
+            )
+        })
+
+        it("should throw when the attestation is not signed by the attestation owner", async () => {
+            await expect(easExcubia.check(signerAddress, invalidAttesterAttestationId)).to.be.revertedWithCustomError(
+                easExcubia,
+                "UnexpectedAttester"
+            )
+        })
+
+        it("should pass the check", async () => {
+            const passed = await easExcubia.check(signerAddress, validAttestationId)
+
+            expect(passed).to.be.true
+            // check does NOT change the state of the contract (see pass()).
+            expect(await easExcubia.registeredAttestations(validAttestationId)).to.be.false
+        })
+    })
+
+    describe("pass()", function () {
+        it("should throw when the callee is not the gate", async () => {
+            await expect(
+                easExcubia.connect(signer).pass(signerAddress, invalidRecipientAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "GateOnly")
+        })
+
+        it("should throw when the attestation is not owned by the correct recipient", async () => {
+            await expect(
+                easExcubia.connect(gate).pass(signerAddress, invalidRecipientAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "UnexpectedRecipient")
+        })
+
+        it("should throw when the attestation has been revoked", async () => {
+            await expect(
+                easExcubia.connect(gate).pass(signerAddress, revokedAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "RevokedAttestation")
+        })
+
+        it("should throw when the attestation schema is not the one expected", async () => {
+            await expect(
+                easExcubia.connect(gate).pass(signerAddress, invalidSchemaAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "UnexpectedSchema")
+        })
+
+        it("should throw when the attestation is not signed by the attestation owner", async () => {
+            await expect(
+                easExcubia.connect(gate).pass(signerAddress, invalidAttesterAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "UnexpectedAttester")
+        })
+
+        it("should pass the check", async () => {
+            const tx = await easExcubia.connect(gate).pass(signerAddress, validAttestationId)
+            const receipt = await tx.wait()
+            const event = EASExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    passerby: string
+                    gate: string
+                }
+            }
+
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.passerby).to.eq(signerAddress)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await easExcubia.registeredAttestations(validAttestationId)).to.be.true
+        })
+
+        it("should prevent to pass twice", async () => {
+            await expect(
+                easExcubia.connect(gate).pass(signerAddress, validAttestationId)
+            ).to.be.revertedWithCustomError(easExcubia, "AlreadyRegistered")
         })
     })
 })

--- a/packages/excubiae/test/EASExcubia.test.ts
+++ b/packages/excubiae/test/EASExcubia.test.ts
@@ -185,7 +185,7 @@ describe("EASExcubia", function () {
         it("should prevent to pass twice", async () => {
             await expect(
                 easExcubia.connect(gate).pass(signerAddress, validAttestationId)
-            ).to.be.revertedWithCustomError(easExcubia, "AlreadyRegistered")
+            ).to.be.revertedWithCustomError(easExcubia, "AlreadyPassed")
         })
     })
 })

--- a/packages/excubiae/test/ERC721Excubia.test.ts
+++ b/packages/excubiae/test/ERC721Excubia.test.ts
@@ -152,7 +152,7 @@ describe("ERC721Excubia", function () {
         it("should prevent to pass twice", async () => {
             await expect(
                 erc721Excubia.connect(gate).pass(signerAddress, encodedValidTokenId)
-            ).to.be.revertedWithCustomError(erc721Excubia, "AlreadyRegistered")
+            ).to.be.revertedWithCustomError(erc721Excubia, "AlreadyPassed")
         })
     })
 })

--- a/packages/excubiae/test/ERC721Excubia.test.ts
+++ b/packages/excubiae/test/ERC721Excubia.test.ts
@@ -1,0 +1,157 @@
+import { expect } from "chai"
+import { ethers } from "hardhat"
+import { AbiCoder, Signer, ZeroAddress } from "ethers"
+import { ERC721Excubia, ERC721Excubia__factory, MockERC721, MockERC721__factory } from "../typechain-types"
+
+describe("ERC721Excubia", function () {
+    let MockERC721Contract: MockERC721__factory
+    let ERC721ExcubiaContract: ERC721Excubia__factory
+    let erc721Excubia: ERC721Excubia
+
+    let signer: Signer
+    let signerAddress: string
+
+    let gate: Signer
+    let gateAddress: string
+
+    let anotherTokenOwner: Signer
+    let anotherTokenOwnerAddress: string
+
+    let mockERC721: MockERC721
+    let mockERC721Address: string
+
+    const encodedValidTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [0])
+    const encodedInvalidOwnerTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [1])
+    const decodedValidTokenId = AbiCoder.defaultAbiCoder().decode(["uint256"], encodedValidTokenId)
+    const decodedInvalidOwnerTokenId = AbiCoder.defaultAbiCoder().decode(["uint256"], encodedInvalidOwnerTokenId)
+
+    before(async function () {
+        ;[signer, gate, anotherTokenOwner] = await ethers.getSigners()
+        signerAddress = await signer.getAddress()
+        gateAddress = await gate.getAddress()
+        anotherTokenOwnerAddress = await anotherTokenOwner.getAddress()
+
+        MockERC721Contract = await ethers.getContractFactory("MockERC721")
+        mockERC721 = await MockERC721Contract.deploy()
+        mockERC721Address = await mockERC721.getAddress()
+
+        // assign to `signerAddress` token with id equal to `1`.
+        await mockERC721.mintAndGiveToken(signerAddress)
+        await mockERC721.mintAndGiveToken(anotherTokenOwnerAddress)
+
+        ERC721ExcubiaContract = await ethers.getContractFactory("ERC721Excubia")
+        erc721Excubia = await ERC721ExcubiaContract.deploy(mockERC721Address)
+    })
+
+    describe("constructor()", function () {
+        it("Should deploy the ERC721Excubia contract correctly", async function () {
+            expect(erc721Excubia).to.not.eq(undefined)
+        })
+
+        it("Should deploy the MockERC721 contract correctly", async function () {
+            expect(mockERC721).to.not.eq(undefined)
+        })
+
+        it("Should fail to deploy ERC721Excubia when erc721 parameter is not valid", async () => {
+            await expect(ERC721ExcubiaContract.deploy(ZeroAddress)).to.be.revertedWithCustomError(
+                erc721Excubia,
+                "ZeroAddress"
+            )
+        })
+    })
+
+    describe("setGate()", function () {
+        it("should fail to set the gate when the caller is not the owner", async () => {
+            const [, notOwnerSigner] = await ethers.getSigners()
+
+            await expect(erc721Excubia.connect(notOwnerSigner).setGate(gateAddress)).to.be.revertedWithCustomError(
+                erc721Excubia,
+                "OwnableUnauthorizedAccount"
+            )
+        })
+
+        it("should fail to set the gate when the gate address is zero", async () => {
+            await expect(erc721Excubia.setGate(ZeroAddress)).to.be.revertedWithCustomError(erc721Excubia, "ZeroAddress")
+        })
+
+        it("Should set the gate contract address correctly", async function () {
+            const tx = await erc721Excubia.setGate(gateAddress)
+            const receipt = await tx.wait()
+            const event = ERC721ExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    gate: string
+                }
+            }
+
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await erc721Excubia.gate()).to.eq(gateAddress)
+        })
+
+        it("Should fail to set the gate if already set", async function () {
+            await expect(erc721Excubia.setGate(gateAddress)).to.be.revertedWithCustomError(
+                erc721Excubia,
+                "GateAlreadySet"
+            )
+        })
+    })
+
+    describe("check()", function () {
+        it("should throw when the token id is not owned by the correct recipient", async () => {
+            expect(await mockERC721.ownerOf(encodedInvalidOwnerTokenId)).to.be.equal(anotherTokenOwnerAddress)
+
+            await expect(erc721Excubia.check(signerAddress, encodedInvalidOwnerTokenId)).to.be.revertedWithCustomError(
+                erc721Excubia,
+                "UnexpectedTokenOwner"
+            )
+        })
+
+        it("should pass the check", async () => {
+            const passed = await erc721Excubia.check(signerAddress, encodedValidTokenId)
+
+            expect(passed).to.be.true
+            // check does NOT change the state of the contract (see pass()).
+            expect(await erc721Excubia.registeredTokenIds(decodedValidTokenId[0])).to.be.false
+        })
+    })
+
+    describe("pass()", function () {
+        it("should throw when the callee is not the gate", async () => {
+            await expect(
+                erc721Excubia.connect(signer).pass(signerAddress, encodedInvalidOwnerTokenId)
+            ).to.be.revertedWithCustomError(erc721Excubia, "GateOnly")
+        })
+
+        it("should throw when the token id is not owned by the correct recipient", async () => {
+            await expect(
+                erc721Excubia.connect(gate).pass(signerAddress, encodedInvalidOwnerTokenId)
+            ).to.be.revertedWithCustomError(erc721Excubia, "UnexpectedTokenOwner")
+        })
+
+        it("should pass the check", async () => {
+            const tx = await erc721Excubia.connect(gate).pass(signerAddress, encodedValidTokenId)
+            const receipt = await tx.wait()
+            const event = ERC721ExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    passerby: string
+                    gate: string
+                }
+            }
+
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.passerby).to.eq(signerAddress)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await erc721Excubia.registeredTokenIds(decodedValidTokenId[0])).to.be.true
+        })
+
+        it("should prevent to pass twice", async () => {
+            await expect(
+                erc721Excubia.connect(gate).pass(signerAddress, encodedValidTokenId)
+            ).to.be.revertedWithCustomError(erc721Excubia, "AlreadyRegistered")
+        })
+    })
+})

--- a/packages/excubiae/test/ERC721Excubia.test.ts
+++ b/packages/excubiae/test/ERC721Excubia.test.ts
@@ -20,10 +20,11 @@ describe("ERC721Excubia", function () {
     let mockERC721: MockERC721
     let mockERC721Address: string
 
-    const encodedValidTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [0])
-    const encodedInvalidOwnerTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [1])
-    const decodedValidTokenId = AbiCoder.defaultAbiCoder().decode(["uint256"], encodedValidTokenId)
-    const decodedInvalidOwnerTokenId = AbiCoder.defaultAbiCoder().decode(["uint256"], encodedInvalidOwnerTokenId)
+    const rawValidTokenId = 0
+    const rawInvalidOwnerTokenId = 1
+
+    const encodedValidTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [rawValidTokenId])
+    const encodedInvalidOwnerTokenId = AbiCoder.defaultAbiCoder().encode(["uint256"], [rawInvalidOwnerTokenId])
 
     before(async function () {
         ;[signer, gate, anotherTokenOwner] = await ethers.getSigners()
@@ -108,12 +109,12 @@ describe("ERC721Excubia", function () {
             )
         })
 
-        it("should pass the check", async () => {
+        it("should check", async () => {
             const passed = await erc721Excubia.check(signerAddress, encodedValidTokenId)
 
             expect(passed).to.be.true
             // check does NOT change the state of the contract (see pass()).
-            expect(await erc721Excubia.registeredTokenIds(decodedValidTokenId[0])).to.be.false
+            expect(await erc721Excubia.registeredTokenIds(rawValidTokenId)).to.be.false
         })
     })
 
@@ -130,7 +131,7 @@ describe("ERC721Excubia", function () {
             ).to.be.revertedWithCustomError(erc721Excubia, "UnexpectedTokenOwner")
         })
 
-        it("should pass the check", async () => {
+        it("should pass", async () => {
             const tx = await erc721Excubia.connect(gate).pass(signerAddress, encodedValidTokenId)
             const receipt = await tx.wait()
             const event = ERC721ExcubiaContract.interface.parseLog(
@@ -145,7 +146,7 @@ describe("ERC721Excubia", function () {
             expect(receipt?.status).to.eq(1)
             expect(event.args.passerby).to.eq(signerAddress)
             expect(event.args.gate).to.eq(gateAddress)
-            expect(await erc721Excubia.registeredTokenIds(decodedValidTokenId[0])).to.be.true
+            expect(await erc721Excubia.registeredTokenIds(rawValidTokenId)).to.be.true
         })
 
         it("should prevent to pass twice", async () => {

--- a/packages/excubiae/test/FreeForAllExcubia.test.ts
+++ b/packages/excubiae/test/FreeForAllExcubia.test.ts
@@ -70,13 +70,13 @@ describe("FreeForAllExcubia", function () {
     })
 
     describe("check()", function () {
-        it("should pass the check", async () => {
+        it("should check", async () => {
             // `data` parameter value can be whatever (e.g., ZeroHash default).
             const passed = await freeForAllExcubia.check(signerAddress, ZeroHash)
 
             expect(passed).to.be.true
             // check does NOT change the state of the contract (see pass()).
-            expect(await freeForAllExcubia.registeredPassersby(ethers.keccak256(signerAddress))).to.be.false
+            expect(await freeForAllExcubia.registeredPassersby(signerAddress)).to.be.false
         })
     })
 
@@ -88,7 +88,7 @@ describe("FreeForAllExcubia", function () {
             ).to.be.revertedWithCustomError(freeForAllExcubia, "GateOnly")
         })
 
-        it("should pass the check", async () => {
+        it("should pass", async () => {
             // `data` parameter value can be whatever (e.g., ZeroHash default).
             const tx = await freeForAllExcubia.connect(gate).pass(signerAddress, ZeroHash)
             const receipt = await tx.wait()
@@ -104,7 +104,7 @@ describe("FreeForAllExcubia", function () {
             expect(receipt?.status).to.eq(1)
             expect(event.args.passerby).to.eq(signerAddress)
             expect(event.args.gate).to.eq(gateAddress)
-            expect(await freeForAllExcubia.registeredPassersby(ethers.keccak256(signerAddress))).to.be.true
+            expect(await freeForAllExcubia.registeredPassersby(signerAddress)).to.be.true
         })
 
         it("should prevent to pass twice", async () => {

--- a/packages/excubiae/test/FreeForAllExcubia.test.ts
+++ b/packages/excubiae/test/FreeForAllExcubia.test.ts
@@ -111,7 +111,7 @@ describe("FreeForAllExcubia", function () {
             await expect(
                 // `data` parameter value can be whatever (e.g., ZeroHash default).
                 freeForAllExcubia.connect(gate).pass(signerAddress, ZeroHash)
-            ).to.be.revertedWithCustomError(freeForAllExcubia, "AlreadyRegistered")
+            ).to.be.revertedWithCustomError(freeForAllExcubia, "AlreadyPassed")
         })
     })
 })

--- a/packages/excubiae/test/FreeForAllExcubia.test.ts
+++ b/packages/excubiae/test/FreeForAllExcubia.test.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai"
+import { ethers } from "hardhat"
+import { Signer, ZeroAddress, ZeroHash } from "ethers"
+import { FreeForAllExcubia, FreeForAllExcubia__factory } from "../typechain-types"
+
+describe("FreeForAllExcubia", function () {
+    let FreeForAllExcubiaContract: FreeForAllExcubia__factory
+    let freeForAllExcubia: FreeForAllExcubia
+
+    let signer: Signer
+    let signerAddress: string
+
+    let gate: Signer
+    let gateAddress: string
+
+    before(async function () {
+        ;[signer, gate] = await ethers.getSigners()
+        signerAddress = await signer.getAddress()
+        gateAddress = await gate.getAddress()
+
+        FreeForAllExcubiaContract = await ethers.getContractFactory("FreeForAllExcubia")
+        freeForAllExcubia = await FreeForAllExcubiaContract.deploy()
+    })
+
+    describe("constructor()", function () {
+        it("Should deploy the FreeForAllExcubia contract correctly", async function () {
+            expect(freeForAllExcubia).to.not.eq(undefined)
+        })
+    })
+
+    describe("setGate()", function () {
+        it("should fail to set the gate when the caller is not the owner", async () => {
+            const [, notOwnerSigner] = await ethers.getSigners()
+
+            await expect(freeForAllExcubia.connect(notOwnerSigner).setGate(gateAddress)).to.be.revertedWithCustomError(
+                freeForAllExcubia,
+                "OwnableUnauthorizedAccount"
+            )
+        })
+
+        it("should fail to set the gate when the gate address is zero", async () => {
+            await expect(freeForAllExcubia.setGate(ZeroAddress)).to.be.revertedWithCustomError(
+                freeForAllExcubia,
+                "ZeroAddress"
+            )
+        })
+
+        it("Should set the gate contract address correctly", async function () {
+            const tx = await freeForAllExcubia.setGate(gateAddress)
+            const receipt = await tx.wait()
+            const event = FreeForAllExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    gate: string
+                }
+            }
+
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await freeForAllExcubia.gate()).to.eq(gateAddress)
+        })
+
+        it("Should fail to set the gate if already set", async function () {
+            await expect(freeForAllExcubia.setGate(gateAddress)).to.be.revertedWithCustomError(
+                freeForAllExcubia,
+                "GateAlreadySet"
+            )
+        })
+    })
+
+    describe("check()", function () {
+        it("should pass the check", async () => {
+            // `data` parameter value can be whatever (e.g., ZeroHash default).
+            const passed = await freeForAllExcubia.check(signerAddress, ZeroHash)
+
+            expect(passed).to.be.true
+            // check does NOT change the state of the contract (see pass()).
+            expect(await freeForAllExcubia.registeredPassersby(ethers.keccak256(signerAddress))).to.be.false
+        })
+    })
+
+    describe("pass()", function () {
+        it("should throw when the callee is not the gate", async () => {
+            await expect(
+                // `data` parameter value can be whatever (e.g., ZeroHash default).
+                freeForAllExcubia.connect(signer).pass(signerAddress, ZeroHash)
+            ).to.be.revertedWithCustomError(freeForAllExcubia, "GateOnly")
+        })
+
+        it("should pass the check", async () => {
+            // `data` parameter value can be whatever (e.g., ZeroHash default).
+            const tx = await freeForAllExcubia.connect(gate).pass(signerAddress, ZeroHash)
+            const receipt = await tx.wait()
+            const event = FreeForAllExcubiaContract.interface.parseLog(
+                receipt?.logs[0] as unknown as { topics: string[]; data: string }
+            ) as unknown as {
+                args: {
+                    passerby: string
+                    gate: string
+                }
+            }
+
+            expect(receipt?.status).to.eq(1)
+            expect(event.args.passerby).to.eq(signerAddress)
+            expect(event.args.gate).to.eq(gateAddress)
+            expect(await freeForAllExcubia.registeredPassersby(ethers.keccak256(signerAddress))).to.be.true
+        })
+
+        it("should prevent to pass twice", async () => {
+            await expect(
+                // `data` parameter value can be whatever (e.g., ZeroHash default).
+                freeForAllExcubia.connect(gate).pass(signerAddress, ZeroHash)
+            ).to.be.revertedWithCustomError(freeForAllExcubia, "AlreadyRegistered")
+        })
+    })
+})


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

This PR introduces `FreeForAll` and `SignUpToken` MACI's gatekeepers as Excubia w/ some new features:
- [x] [FreeForAllGatekeeper](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/gatekeepers/FreeForAllSignUpGatekeeper.sol) (added logic to avoid passing twice with the same address).
- [x] [SignUpTokenGatekeeper](https://github.com/privacy-scaling-explorations/maci/blob/dev/contracts/contracts/gatekeepers/SignUpTokenGatekeeper.sol) (evolved to support whatever ERC721 contract).

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)
see #18 
needs #17 
<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn compile` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
