### PR TITLE
ci: fix coveralls workflow step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,15 +111,13 @@ jobs:
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run test:coverage
 
-    coveralls:
-        runs-on: ubuntu-latest
-        if: needs.changed-files.outputs.any_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        needs: [changed-files, tests]
-        steps:
-            - name: Coveralls
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir) && github.event_name == 'push' && github.ref == 'refs/heads/main'
+              name: Coveralls
               uses: coverallsapp/github-action@v2
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  parallel: true
+                  flag-name: run ${{ join(matrix.*, '-') }}
 
     set-matrix:
         if: needs.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
Culprit was running the coveralls action in a separate job. Indeed, job contexts being isolated, the [coveralls context didn't have any coverage data](https://github.com/privacy-scaling-explorations/zk-kit.solidity/actions/runs/9762627031/job/26946626860#step:2:49). And the default behavior of the coveralls action is to report a failure in that case.  
The fix consists in running `coverallsapp/github-action` in parallel in the `tests` job.

## Note
I am aware of the stuck test ci checks:

![image](https://github.com/privacy-scaling-explorations/zk-kit.solidity/assets/38692952/9b441a2f-abd1-44ca-8219-f2db572f19d6)

This is due to a GH action limitation: ci required checks defined in rulesets/branch protection rules are always required, no matter if the corresponding job was skipped or not. And our workflow does conditionally skip jobs...
There seems to be some workarounds described [here](https://github.com/orgs/community/discussions/13690) that I will try later.
In the meantime please ignore these stuck ci checks please.