### PR TITLE
ci: make required checks passed if skipped

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,7 @@ name: main
 on:
     push:
         branches: [main]
-        paths: ["**/*.js", "**/*.json", "**/*.md", "**/*.sol", "**/*.ts", "**/*.yaml", "**/*.yml"]
     pull_request:
-        paths: ["**/*.js", "**/*.json", "**/*.md", "**/*.sol", "**/*.ts", "**/*.yaml", "**/*.yml"]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -39,18 +37,18 @@ jobs:
     changed-files:
         runs-on: ubuntu-latest
         outputs:
-            sol_any_changed: ${{ steps.changed-files.outputs.any_changed }}
-            sol_modified_files: ${{ steps.changed-files.outputs.modified_files }}
+            any_changed: ${{ steps.changed-files.outputs.any_changed }}
+            modified_files: ${{ steps.changed-files.outputs.modified_files }}
         steps:
             - uses: actions/checkout@v4
             - name: Get changed files
               id: changed-files
               uses: tj-actions/changed-files@v44
               with:
-                  files: packages/**/*.sol
+                  files: packages/**/*.{json,sol,ts}
 
     compile:
-        if: needs.changed-files.outputs.sol_any_changed == 'true'
+        if: needs.changed-files.outputs.any_changed == 'true'
         needs: [changed-files, deps]
         runs-on: ubuntu-latest
         steps:
@@ -87,7 +85,7 @@ jobs:
             - run: yarn format
 
     _tests:
-        if: needs.changed-files.outputs.sol_any_changed == 'true'
+        if: needs.changed-files.outputs.any_changed == 'true'
         needs: compile
         runs-on: ubuntu-latest
         strategy:
@@ -108,13 +106,13 @@ jobs:
                   name: all-artifacts
                   path: packages/
 
-            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Test
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run test:coverage
 
-            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir) && github.event_name == 'push' && github.ref == 'refs/heads/main'
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir) && github.event_name == 'push' && github.ref == 'refs/heads/main'
               name: Coveralls
               uses: coverallsapp/github-action@v2
               with:
@@ -133,7 +131,7 @@ jobs:
               run: true
 
     set-matrix:
-        if: needs.changed-files.outputs.sol_any_changed == 'true'
+        if: needs.changed-files.outputs.any_changed == 'true'
         needs: changed-files
         runs-on: ubuntu-latest
         outputs:
@@ -147,7 +145,7 @@ jobs:
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
     _slither:
-        if: needs.changed-files.outputs.sol_any_changed == 'true'
+        if: needs.changed-files.outputs.any_changed == 'true'
         needs: [changed-files, set-matrix, deps]
         runs-on: ubuntu-latest
         permissions:
@@ -172,13 +170,13 @@ jobs:
               with:
                   path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
-            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Compile contracts
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 
-            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
@@ -190,7 +188,7 @@ jobs:
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
 
-            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
               name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,9 @@ name: main
 on:
     push:
         branches: [main]
+        paths: ["**/*.js", "**/*.json", "**/*.md", "**/*.sol", "**/*.ts", "**/*.yaml", "**/*.yml"]
     pull_request:
+        paths: ["**/*.js", "**/*.json", "**/*.md", "**/*.sol", "**/*.ts", "**/*.yaml", "**/*.yml"]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -37,18 +39,18 @@ jobs:
     changed-files:
         runs-on: ubuntu-latest
         outputs:
-            any_changed: ${{ steps.changed-files.outputs.any_changed }}
-            modified_files: ${{ steps.changed-files.outputs.modified_files }}
+            sol_any_changed: ${{ steps.changed-files.outputs.any_changed }}
+            sol_modified_files: ${{ steps.changed-files.outputs.modified_files }}
         steps:
             - uses: actions/checkout@v4
             - name: Get changed files
               id: changed-files
               uses: tj-actions/changed-files@v44
               with:
-                  files: packages/**/*.{sol,json,ts}
+                  files: packages/**/*.sol
 
     compile:
-        if: needs.changed-files.outputs.any_changed == 'true'
+        if: needs.changed-files.outputs.sol_any_changed == 'true'
         needs: [changed-files, deps]
         runs-on: ubuntu-latest
         steps:
@@ -83,9 +85,10 @@ jobs:
                   key: ${{ needs.deps.outputs.cache-key }}
 
             - run: yarn format
-    tests:
-        if: needs.changed-files.outputs.any_changed == 'true'
-        needs: [changed-files, set-matrix, deps, compile]
+
+    _tests:
+        if: needs.changed-files.outputs.sol_any_changed == 'true'
+        needs: compile
         runs-on: ubuntu-latest
         strategy:
             matrix:
@@ -105,13 +108,13 @@ jobs:
                   name: all-artifacts
                   path: packages/
 
-            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
               name: Test
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run test:coverage
 
-            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir) && github.event_name == 'push' && github.ref == 'refs/heads/main'
+            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir) && github.event_name == 'push' && github.ref == 'refs/heads/main'
               name: Coveralls
               uses: coverallsapp/github-action@v2
               with:
@@ -119,8 +122,18 @@ jobs:
                   parallel: true
                   flag-name: run ${{ join(matrix.*, '-') }}
 
+    tests:
+        needs: _tests
+        # workaround for https://github.com/orgs/community/discussions/13690
+        # https://stackoverflow.com/a/77066140/9771158
+        if: ${{ !(failure() || cancelled()) }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Tests OK (passed or skipped)
+              run: true
+
     set-matrix:
-        if: needs.changed-files.outputs.any_changed == 'true'
+        if: needs.changed-files.outputs.sol_any_changed == 'true'
         needs: changed-files
         runs-on: ubuntu-latest
         outputs:
@@ -133,8 +146,8 @@ jobs:
                   matrix=$(ls -1 packages | jq -Rsc 'split("\n") | map(select(length > 0))')
                   echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
-    slither:
-        if: needs.changed-files.outputs.any_changed == 'true'
+    _slither:
+        if: needs.changed-files.outputs.sol_any_changed == 'true'
         needs: [changed-files, set-matrix, deps]
         runs-on: ubuntu-latest
         permissions:
@@ -159,13 +172,13 @@ jobs:
               with:
                   path: node_modules
                   key: ${{ needs.deps.outputs.cache-key }}
-            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
               name: Compile contracts
               run: |
                   workspace=$(jq -r '.name' packages/${{ matrix.dir }}/package.json)
                   yarn workspace "$workspace" run compile
 
-            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
               name: Run slither
               uses: crytic/slither-action@v0.4.0
               id: slither
@@ -177,7 +190,7 @@ jobs:
                   slither-args: --filter-paths "test" --exclude-dependencies --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
                   target: packages/${{ matrix.dir }}
 
-            - if: contains(needs.changed-files.outputs.modified_files, matrix.dir)
+            - if: contains(needs.changed-files.outputs.sol_modified_files, matrix.dir)
               name: Upload SARIF files
               uses: github/codeql-action/upload-sarif@v3
               with:
@@ -194,3 +207,11 @@ jobs:
                       const header = '# Slither report'
                       const body = process.env.REPORT
                       await script({ github, context, header, body })
+
+    slither:
+        needs: _slither
+        if: ${{ !(failure() || cancelled()) }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Slither analysis OK (passed or skipped)
+              run: true


### PR DESCRIPTION
Fix #22 

A [limitation of GitHub actions](https://github.com/orgs/community/discussions/13690) is that ci jobs that used as checks required to allow a PR to merge, are **always** required, even if they were skipped.  
In the case they were skipped...well the ci check isn't passed, not allowing a valid PR to merge.  

A [workaround](https://stackoverflow.com/a/77066140/9771158) is to use  `${{ !(failure() || cancelled()) }}` as a condition, meaning: if the dependents jobs didn't fail or weren't cancelled, execute (especially: if dependents jobs were skipped, execute).  
This can be used as an `if` condition in a dummy job that will always be executed and successful, **unless the dependents jobs failed or were cancelled**. Which is what we want.

The [workflow diagram](https://github.com/privacy-scaling-explorations/zk-kit.solidity/actions/runs/10297770771) illustrates well what is going on:
![image](https://github.com/user-attachments/assets/83d4728a-ee5f-45eb-9a40-ea7faf2e4bbe)

This PR does not affect any `sol` files, so the `_tests` and `_slither` matrix jobs are all skipped.
However `tests` and `slither` which depends on `_tests` and `_slither` respectively and are used as ci required checks, are still executed and pass, allowing the PR to merge.


This will speed up even more the CI, and avoid ci checks being a stuck with `waiting for status to be reported` state.