### PR TITLE
Deprecate `@zk-kit/excubiae`

### DIFF
--- a/packages/excubiae/contracts/README.md
+++ b/packages/excubiae/contracts/README.md
@@ -1,38 +1,20 @@
 <p align="center">
     <h1 align="center">
-        Excubiae
+        [DEPRECATED] Excubiae
     </h1>
     <p align="center">A flexible and modular framework for general-purpose on-chain gatekeepers.</p>
 </p>
 
-<p align="center">
-    <a href="https://github.com/privacy-scaling-explorations/excubiae">
-        <img src="https://img.shields.io/badge/project-excubiae-blue.svg?style=flat-square">
-    </a>
-    <a href="https://github.com/privacy-scaling-explorations/excubiae/blob/main/LICENSE">
-        <img alt="NPM license" src="https://img.shields.io/npm/l/excubiae?style=flat-square">
-    </a>
-    <a href="https://www.npmjs.com/package/excubiae">
-        <img alt="NPM version" src="https://img.shields.io/npm/v/excubiae?style=flat-square" />
-    </a>
-    <a href="https://npmjs.org/package/excubiae">
-        <img alt="Downloads" src="https://img.shields.io/npm/dm/excubiae.svg?style=flat-square" />
-    </a>
-    <a href="https://prettier.io/">
-        <img alt="Code style prettier" src="https://img.shields.io/badge/code%20style-prettier-f8bc45?style=flat-square&logo=prettier" />
-    </a>
+<p align="center">    
+    <img alt="No Maintenance" src="https://img.shields.io/maintenance/no/2024.svg">
 </p>
 
-<div align="center">
-    <h4>
-        <a href="https://appliedzkp.org/discord">
-            🗣️ Chat & Support
-        </a>
-    </h4>
-</div>
+> [!NOTE]
+> This package has been DEPRECATED. Please, refer to [@excubiae/contracts](https://www.npmjs.com/package/@excubiae/contracts) on [excubiae](https://github.com/privacy-scaling-explorations/excubiae) monorepo.
 
-> [!NOTE]  
-> This library is experimental and untested yet - use at your own discretion...
+---
+
+---
 
 Excubiae is a generalized framework for on-chain gatekeepers that allows developers to define custom access control mechanisms using different on-chain credentials. By abstracting the gatekeeper logic, excubiae provides a reusable and composable solution for securing decentralised applications. This package provides a pre-defined set of specific excubia (_extensions_) for credentials based on different protocols.
 

--- a/packages/excubiae/contracts/package.json
+++ b/packages/excubiae/contracts/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zk-kit/excubiae",
     "version": "0.1.0",
-    "description": "A general purpose on-chain gatekeeping smart contract framework.",
+    "description": "[DEPRECATED] A general purpose on-chain gatekeeping smart contract framework.",
     "license": "MIT",
     "files": [
         "*.sol",
@@ -10,6 +10,7 @@
         "LICENSE"
     ],
     "keywords": [
+        "deprecated",
         "blockchain",
         "ethereum",
         "hardhat",

--- a/packages/excubiae/contracts/package.json
+++ b/packages/excubiae/contracts/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zk-kit/excubiae",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "[DEPRECATED] A general purpose on-chain gatekeeping smart contract framework.",
     "license": "MIT",
     "files": [


### PR DESCRIPTION
## Description
`excubiae` has been officially released as v0.1.0 today. The code lives in the `excubiae` [monorepo](https://github.com/privacy-scaling-explorations/excubiae). Therefore, this prototype package on zk-kit must be deprecated as no longer maintained.

I'm following this [guide](https://gist.github.com/alebelcor/9232ae5c7ac387b8dc1dc4102f328b58) for the deprecation of the package.