### PR TITLE
Fix Incorrect Link to Slither Installation Guide

### DIFF
--- a/scripts/check-slither.sh
+++ b/scripts/check-slither.sh
@@ -11,7 +11,7 @@ log() {
 
 main() {
   if ! command -v slither >/dev/null; then
-    log "${RED}error: slither is required but is not installed${RESET}.\nFollow instructions at ${CYAN}https://github.com/crytic/slither?tab=readme-ov-file#how-to-install${RESET} and try again."
+    log "${RED}error: slither is required but is not installed${RESET}.\nFollow instructions at ${CYAN}https://github.com/crytic/slither#how-to-install${RESET} and try again."
     exit 1
   fi
 }


### PR DESCRIPTION
An issue was identified in the shell script where the link to the Slither installation guide was incorrectly formatted:

```sh
https://github.com/crytic/slither?tab=readme-ov-file#how-to-install
```

The parameter `?tab=readme-ov-file` is invalid and leads to a broken or incorrect page. The corrected link is:

```sh
https://github.com/crytic/slither#how-to-install
```

This adjustment ensures users are directed to the correct section in the official `Slither` documentation, improving their ability to follow the installation process seamlessly.


## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn compile` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
