### PR TITLE
fix(lean-imt): update stale side nodes values when performing a leaf node update

### DIFF
--- a/packages/lean-imt/contracts/InternalLeanIMT.sol
+++ b/packages/lean-imt/contracts/InternalLeanIMT.sol
@@ -256,6 +256,10 @@ library InternalLeanIMT {
                     revert LeafGreaterThanSnarkScalarField();
                 }
 
+                if (self.sideNodes[level] == oldRoot) {
+                    self.sideNodes[level] = node;
+                }
+
                 node = PoseidonT3.hash([siblingNodes[i], node]);
                 oldRoot = PoseidonT3.hash([siblingNodes[i], oldRoot]);
 
@@ -268,6 +272,10 @@ library InternalLeanIMT {
                         revert LeafGreaterThanSnarkScalarField();
                     }
 
+                    if (self.sideNodes[level] == oldRoot) {
+                        self.sideNodes[level] = node;
+                    }
+
                     node = PoseidonT3.hash([node, siblingNodes[i]]);
                     oldRoot = PoseidonT3.hash([oldRoot, siblingNodes[i]]);
 
@@ -275,7 +283,7 @@ library InternalLeanIMT {
                         ++i;
                     }
                 } else {
-                    self.sideNodes[i] = node;
+                    self.sideNodes[level] = node;
                 }
             }
 

--- a/packages/lean-imt/contracts/InternalLeanIMT.sol
+++ b/packages/lean-imt/contracts/InternalLeanIMT.sol
@@ -256,10 +256,6 @@ library InternalLeanIMT {
                     revert LeafGreaterThanSnarkScalarField();
                 }
 
-                if (self.sideNodes[level] == oldRoot) {
-                    self.sideNodes[level] = node;
-                }
-
                 node = PoseidonT3.hash([siblingNodes[i], node]);
                 oldRoot = PoseidonT3.hash([siblingNodes[i], oldRoot]);
 

--- a/packages/lean-imt/test/LeanIMT.ts
+++ b/packages/lean-imt/test/LeanIMT.ts
@@ -267,6 +267,26 @@ describe("LeanIMT", () => {
 
             await expect(transaction).to.be.revertedWithCustomError(leanIMT, "LeafAlreadyExists")
         })
+        it("Should maintain correct tree state after multiple updates and inserts", async () => {
+            for (let i = 0; i < 5; i += 1) {
+                jsLeanIMT.insert(BigInt(i + 1))
+                await leanIMTTest.insert(i + 1)
+            }
+
+            for (let i = 0; i < 3; i += 1) {
+                jsLeanIMT.update(i, BigInt(i + 10))
+                const { siblings } = jsLeanIMT.generateProof(i)
+                await leanIMTTest.update(i + 1, i + 10, siblings)
+            }
+
+            for (let i = 5; i < 8; i += 1) {
+                jsLeanIMT.insert(BigInt(i + 1))
+                await leanIMTTest.insert(i + 1)
+            }
+
+            const root = await leanIMTTest.root()
+            expect(root).to.equal(jsLeanIMT.root)
+        })
     })
 
     describe("# remove", () => {


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
When updating a leaf node, intermediate nodes are computed but not used to update the existing side nodes values. The values stored in side nodes need to reflect the new state of the tree with each update operation. This fix ensures that they are updated properly.

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)
#48

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [ ] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
