### PR TITLE
feat(imt): add initialization checks and errors

### DIFF
--- a/packages/imt/contracts/InternalBinaryIMT.sol
+++ b/packages/imt/contracts/InternalBinaryIMT.sol
@@ -7,6 +7,7 @@ import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 // Each incremental tree has certain properties and data that will
 // be used to add new leaves.
 struct BinaryIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint256 depth; // Depth of the tree (levels - 1).
     uint256 root; // Root hash of the tree.
     uint256 numberOfLeaves; // Number of leaves of the tree.
@@ -24,6 +25,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental binary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -105,6 +108,9 @@ library InternalBinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(BinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }        
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -123,9 +129,13 @@ library InternalBinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     function _initWithDefaultZeroes(BinaryIMTData storage self, uint256 depth) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         if (depth <= 0 || depth > MAX_DEPTH) {
             revert DepthNotSupported();
         }
@@ -134,13 +144,18 @@ library InternalBinaryIMT {
         self.useDefaultZeroes = true;
 
         self.root = _defaultZero(depth);
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(BinaryIMTData storage self, uint256 leaf) internal returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint256 depth = self.depth;
+        
 
         if (leaf >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
@@ -185,6 +200,9 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -237,6 +255,9 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         _update(self, leaf, self.useDefaultZeroes ? Z_0 : self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/imt/contracts/InternalQuinaryIMT.sol
+++ b/packages/imt/contracts/InternalQuinaryIMT.sol
@@ -7,6 +7,7 @@ import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 // Each incremental tree has certain properties and data that will
 // be used to add new leaves.
 struct QuinaryIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint256 depth; // Depth of the tree (levels - 1).
     uint256 root; // Root hash of the tree.
     uint256 numberOfLeaves; // Number of leaves of the tree.
@@ -22,6 +23,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental quinary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -32,6 +35,9 @@ library InternalQuinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(QuinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -59,13 +65,18 @@ library InternalQuinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(QuinaryIMTData storage self, uint256 leaf) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint256 depth = self.depth;
+
 
         if (leaf >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
@@ -115,6 +126,9 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -173,6 +187,9 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         _update(self, leaf, self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/lazy-imt/contracts/InternalLazyIMT.sol
+++ b/packages/lazy-imt/contracts/InternalLazyIMT.sol
@@ -5,10 +5,14 @@ import {PoseidonT3} from "poseidon-solidity/PoseidonT3.sol";
 import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 
 struct LazyIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint40 maxIndex;
     uint40 numberOfLeaves;
     mapping(uint256 => uint256) elements;
 }
+
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 library InternalLazyIMT {
     uint40 internal constant MAX_INDEX = (1 << 32) - 1;
@@ -86,11 +90,18 @@ library InternalLazyIMT {
 
     function _init(LazyIMTData storage self, uint8 depth) internal {
         require(depth <= MAX_DEPTH, "LazyIMT: Tree too large");
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         self.maxIndex = uint40((1 << depth) - 1);
         self.numberOfLeaves = 0;
+        self.initialized = true;
     }
 
     function _reset(LazyIMTData storage self) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         self.numberOfLeaves = 0;
     }
 
@@ -101,9 +112,12 @@ library InternalLazyIMT {
 
     function _insert(LazyIMTData storage self, uint256 leaf) internal {
         uint40 index = self.numberOfLeaves;
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         require(index < self.maxIndex, "LazyIMT: tree is full");
-
+        
         self.numberOfLeaves = index + 1;
 
         uint256 hash = leaf;
@@ -122,6 +136,9 @@ library InternalLazyIMT {
     }
 
     function _update(LazyIMTData storage self, uint256 leaf, uint40 index) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
@@ -147,6 +164,9 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         // this will always short circuit if self.numberOfLeaves == 0
         uint40 numberOfLeaves = self.numberOfLeaves;
         // dynamically determine a depth
@@ -158,6 +178,9 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
@@ -218,6 +241,9 @@ library InternalLazyIMT {
         uint40 index,
         uint8 depth
     ) internal view returns (uint256[] memory) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
 


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->


## Description

<!-- Describe your changes in detail. -->
This change adds a safety check to our Merkle Tree libraries (`InternalBinaryIMT`, `InternalQuinaryIMT`, `InternalLazyIMT`). We've added an `initialized` flag to their respective data structures (`BinaryIMTData`, `QuinaryIMTData`, `LazyIMTData`) to track whether the tree has been set up properly. This prevents the `init` functions from being called multiple times and ensures other functions are only called after initialization.

<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
It's a **feature** enhancement and **bug fix** aimed at improving robustness and preventing potential misuse, addressing the issue where `init` could be called multiple times.

<!-- What is the current behavior?** (You can also link to an open issue here) -->
Currently, it's possible to call functions like `_insert` or `_update` on a tree instance before it has been initialized using `_init` or `_initWithDefaultZeroes`. Additionally, the `init` functions themselves can be called multiple times on the same tree instance, potentially resetting its state unexpectedly. This is described in issue #42.

<!-- What is the new behavior (if this is a feature change)? -->
With this change:
1.  An `initialized` boolean flag is added to `BinaryIMTData`, `QuinaryIMTData`, and `LazyIMTData`.
2.  The `_init` and `_initWithDefaultZeroes` functions now check this flag. If the tree is already initialized, they'll revert with a new `TreeAlreadyInitialized` error. Upon successful initialization, they set the `initialized` flag to `true`.
3.  All other core functions (`_insert`, `_update`, `_delete`, `_root`, `_path`, etc.) now check the `initialized` flag at the beginning. If the flag is `false`, they revert with a new `TreeNotInitialized` error.

This ensures trees are explicitly initialized before use and provides clear errors if they aren't, or if initialization is attempted twice.

<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
**Heads up: Yes, this is a breaking change.** Anyone using these internal libraries directly must ensure they call an initialization function (`_init` or `_initWithDefaultZeroes`) *before* calling any other function on the tree data structure, and *only once*. Contracts relying on the previous behavior (where operations on uninitialized trees might have occurred silently or where `init` could be called multiple times) will now fail explicitly with `TreeNotInitialized` or `TreeAlreadyInitialized` errors. Logic needs to be updated to accommodate this mandatory, single initialization step.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
Fixes #42



## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas (especially the new `initialized` flag and error conditions).
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works (specifically testing the `TreeNotInitialized` and `TreeAlreadyInitialized` revert conditions).
-   [ ] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.