### PR TITLE
fix(imt, lazy-imt): prevent double init and uninitialized use

### DIFF
--- a/packages/imt/contracts/InternalBinaryIMT.sol
+++ b/packages/imt/contracts/InternalBinaryIMT.sol
@@ -14,6 +14,7 @@ struct BinaryIMTData {
     // The nodes of the subtrees used in the last addition of a leaf (level -> [left node, right node]).
     mapping(uint256 => uint256[2]) lastSubtrees; // Caching these values is essential to efficient appends.
     bool useDefaultZeroes;
+    bool initialized;
 }
 
 error ValueGreaterThanSnarkScalarField();
@@ -24,6 +25,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental binary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -105,6 +108,10 @@ library InternalBinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(BinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
+
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -123,9 +130,14 @@ library InternalBinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     function _initWithDefaultZeroes(BinaryIMTData storage self, uint256 depth) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
+
         if (depth <= 0 || depth > MAX_DEPTH) {
             revert DepthNotSupported();
         }
@@ -134,12 +146,17 @@ library InternalBinaryIMT {
         self.useDefaultZeroes = true;
 
         self.root = _defaultZero(depth);
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(BinaryIMTData storage self, uint256 leaf) internal returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         uint256 depth = self.depth;
 
         if (leaf >= SNARK_SCALAR_FIELD) {
@@ -185,6 +202,10 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -237,6 +258,10 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         _update(self, leaf, self.useDefaultZeroes ? Z_0 : self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/imt/contracts/InternalQuinaryIMT.sol
+++ b/packages/imt/contracts/InternalQuinaryIMT.sol
@@ -13,6 +13,7 @@ struct QuinaryIMTData {
     mapping(uint256 => uint256) zeroes; // Zero hashes used for empty nodes (level -> zero hash).
     // The nodes of the subtrees used in the last addition of a leaf (level -> [nodes]).
     mapping(uint256 => uint256[5]) lastSubtrees; // Caching these values is essential to efficient appends.
+    bool initialized;
 }
 
 error ValueGreaterThanSnarkScalarField();
@@ -22,6 +23,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental quinary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -32,6 +35,10 @@ library InternalQuinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(QuinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
+
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -59,12 +66,17 @@ library InternalQuinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(QuinaryIMTData storage self, uint256 leaf) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         uint256 depth = self.depth;
 
         if (leaf >= SNARK_SCALAR_FIELD) {
@@ -115,6 +127,10 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -173,6 +189,10 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         _update(self, leaf, self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/imt/test/BinaryIMT.ts
+++ b/packages/imt/test/BinaryIMT.ts
@@ -33,6 +33,38 @@ describe("BinaryIMT", () => {
             expect(depth).to.equal(jsBinaryIMT.depth)
         })
 
+        it("Should not re-initialize a tree", async () => {
+            await binaryIMTTest.init(jsBinaryIMT.depth)
+
+            const transaction = binaryIMTTest.init(jsBinaryIMT.depth)
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeAlreadyInitialized")
+        })
+
+        it("Should not re-initialize a tree with default zeroes", async () => {
+            await binaryIMTTest.initWithDefaultZeroes(jsBinaryIMT.depth)
+
+            const transaction = binaryIMTTest.initWithDefaultZeroes(jsBinaryIMT.depth)
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeAlreadyInitialized")
+        })
+
+        it("Should not re-initialize a tree with default zeroes after init", async () => {
+            await binaryIMTTest.init(jsBinaryIMT.depth)
+
+            const transaction = binaryIMTTest.initWithDefaultZeroes(jsBinaryIMT.depth)
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeAlreadyInitialized")
+        })
+
+        it("Should not re-initialize a tree with init after default zeroes", async () => {
+            await binaryIMTTest.initWithDefaultZeroes(jsBinaryIMT.depth)
+
+            const transaction = binaryIMTTest.init(jsBinaryIMT.depth)
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeAlreadyInitialized")
+        })
+
         it("Should create a tree with default zeroes", async () => {
             await binaryIMTTest.initWithDefaultZeroes(jsBinaryIMT.depth)
 
@@ -44,7 +76,15 @@ describe("BinaryIMT", () => {
     })
 
     describe("# insert", () => {
+        it("Should not insert a leaf if the tree is not initialized", async () => {
+            const transaction = binaryIMTTest.insert(1)
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not insert a leaf if its value is > SNARK_SCALAR_FIELD", async () => {
+            await binaryIMTTest.init(jsBinaryIMT.depth)
+
             const transaction = binaryIMTTest.insert(SNARK_SCALAR_FIELD)
 
             await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "ValueGreaterThanSnarkScalarField")
@@ -118,6 +158,12 @@ describe("BinaryIMT", () => {
     })
 
     describe("# update", () => {
+        it("Should not update a leaf if the tree is not initialized", async () => {
+            const transaction = binaryIMTTest.update(1, 2, [0, 1], [0, 1])
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not update a leaf if the new value is the same as the old one", async () => {
             await binaryIMTTest.init(jsBinaryIMT.depth)
             await binaryIMTTest.insert(1)
@@ -250,7 +296,15 @@ describe("BinaryIMT", () => {
     })
 
     describe("# remove", () => {
+        it("Should not remove a leaf if the tree is not initialized", async () => {
+            const transaction = binaryIMTTest.remove(1, [0, 1], [0, 1])
+
+            await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not remove a leaf if its value is > SNARK_SCALAR_FIELD", async () => {
+            await binaryIMTTest.init(jsBinaryIMT.depth)
+
             const transaction = binaryIMTTest.remove(SNARK_SCALAR_FIELD, [0, 1], [0, 1])
 
             await expect(transaction).to.be.revertedWithCustomError(binaryIMT, "ValueGreaterThanSnarkScalarField")

--- a/packages/imt/test/QuinaryIMT.ts
+++ b/packages/imt/test/QuinaryIMT.ts
@@ -32,10 +32,26 @@ describe("QuinaryIMT", () => {
 
             expect(depth).to.equal(jsQuinaryIMT.depth)
         })
+
+        it("Should not re-initialize a tree", async () => {
+            await quinaryIMTTest.init(jsQuinaryIMT.depth)
+
+            const transaction = quinaryIMTTest.init(jsQuinaryIMT.depth)
+
+            await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "TreeAlreadyInitialized")
+        })
     })
 
     describe("# insert", () => {
+        it("Should not insert a leaf if the tree is not initialized", async () => {
+            const transaction = quinaryIMTTest.insert(1)
+
+            await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not insert a leaf if its value is > SNARK_SCALAR_FIELD", async () => {
+            await quinaryIMTTest.init(jsQuinaryIMT.depth)
+
             const transaction = quinaryIMTTest.insert(SNARK_SCALAR_FIELD)
 
             await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "ValueGreaterThanSnarkScalarField")
@@ -82,6 +98,12 @@ describe("QuinaryIMT", () => {
     })
 
     describe("# update", () => {
+        it("Should not update a leaf if the tree is not initialized", async () => {
+            const transaction = quinaryIMTTest.update(1, 2, [[0, 1, 2, 3]], [0])
+
+            await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not update a leaf if the new value is the same as the old one", async () => {
             await quinaryIMTTest.init(jsQuinaryIMT.depth)
             await quinaryIMTTest.insert(1)
@@ -194,7 +216,15 @@ describe("QuinaryIMT", () => {
     })
 
     describe("# remove", () => {
+        it("Should not remove a leaf if the tree is not initialized", async () => {
+            const transaction = quinaryIMTTest.remove(1, [[0, 1, 2, 3]], [0])
+
+            await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "TreeNotInitialized")
+        })
+
         it("Should not remove a leaf if its value is > SNARK_SCALAR_FIELD", async () => {
+            await quinaryIMTTest.init(jsQuinaryIMT.depth)
+
             const transaction = quinaryIMTTest.remove(SNARK_SCALAR_FIELD, [[0, 1, 2, 3]], [0])
 
             await expect(transaction).to.be.revertedWithCustomError(quinaryIMT, "ValueGreaterThanSnarkScalarField")

--- a/packages/lazy-imt/contracts/InternalLazyIMT.sol
+++ b/packages/lazy-imt/contracts/InternalLazyIMT.sol
@@ -5,10 +5,14 @@ import {PoseidonT3} from "poseidon-solidity/PoseidonT3.sol";
 import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 
 struct LazyIMTData {
+    bool initialized;
     uint40 maxIndex;
     uint40 numberOfLeaves;
     mapping(uint256 => uint256) elements;
 }
+
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 library InternalLazyIMT {
     uint40 internal constant MAX_INDEX = (1 << 32) - 1;
@@ -85,12 +89,21 @@ library InternalLazyIMT {
     }
 
     function _init(LazyIMTData storage self, uint8 depth) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
+
         require(depth <= MAX_DEPTH, "LazyIMT: Tree too large");
         self.maxIndex = uint40((1 << depth) - 1);
         self.numberOfLeaves = 0;
+        self.initialized = true;
     }
 
     function _reset(LazyIMTData storage self) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         self.numberOfLeaves = 0;
     }
 
@@ -100,6 +113,10 @@ library InternalLazyIMT {
     }
 
     function _insert(LazyIMTData storage self, uint256 leaf) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         uint40 index = self.numberOfLeaves;
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         require(index < self.maxIndex, "LazyIMT: tree is full");
@@ -122,6 +139,10 @@ library InternalLazyIMT {
     }
 
     function _update(LazyIMTData storage self, uint256 leaf, uint40 index) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
@@ -147,6 +168,10 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         // this will always short circuit if self.numberOfLeaves == 0
         uint40 numberOfLeaves = self.numberOfLeaves;
         // dynamically determine a depth
@@ -158,6 +183,10 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
@@ -218,6 +247,10 @@ library InternalLazyIMT {
         uint40 index,
         uint8 depth
     ) internal view returns (uint256[] memory) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
+
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
 

--- a/packages/lazy-imt/test/LazyIMT.ts
+++ b/packages/lazy-imt/test/LazyIMT.ts
@@ -62,6 +62,52 @@ describe("LazyIMT", () => {
 
             await expect(lazyIMTTest.init(33)).to.be.revertedWith("LazyIMT: Tree too large")
         })
+
+        it("Should not re-initialize a tree", async () => {
+            await lazyIMTTest.init(10)
+
+            const transaction = lazyIMTTest.init(10)
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeAlreadyInitialized")
+        })
+    })
+
+    describe("# initialization guards", () => {
+        it("Should not insert if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.insert(1)
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
+
+        it("Should not update if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.update(1, 0)
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
+
+        it("Should not reset if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.reset()
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
+
+        it("Should not compute root if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.dynamicRoot(10)
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
+
+        it("Should not compute dynamic root if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.root()
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
+
+        it("Should not generate merkle proof if the tree is not initialized", async () => {
+            const transaction = lazyIMTTest.merkleProofElements(0, 10)
+
+            await expect(transaction).to.be.revertedWithCustomError(lazyIMT, "TreeNotInitialized")
+        })
     })
 
     describe("# insert", () => {


### PR DESCRIPTION
## Description

This PR adds a `bool initialized` flag to `BinaryIMTData`, `QuinaryIMTData`, and `LazyIMTData` structs.                                                                         

## Related Issue(s)

Closes #42

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes