### PR TITLE
fix(imt): use index-based parent check for lastSubtrees in _update

### DIFF
--- a/packages/imt/contracts/InternalBinaryIMT.sol
+++ b/packages/imt/contracts/InternalBinaryIMT.sol
@@ -195,32 +195,39 @@ library InternalBinaryIMT {
 
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
-        uint256 updateIndex;
+
+        uint256 updateLeafIndex;
+        for (uint8 i = 0; i < depth; ) {
+            updateLeafIndex |= uint256(proofPathIndices[i]) << uint256(i);
+            unchecked {
+                ++i;
+            }
+        }
+
+        uint256 numberOfLeaves = self.numberOfLeaves;
+
+        if (updateLeafIndex >= numberOfLeaves) {
+            revert LeafIndexOutOfRange();
+        }
+
+        uint256 lastInsertIndex = numberOfLeaves - 1;
 
         for (uint8 i = 0; i < depth; ) {
-            updateIndex |= uint256(proofPathIndices[i]) << uint256(i);
+            // Update lastSubtrees only when update and last insertion
+            // share the same parent node at level i+1
+            if ((updateLeafIndex >> (i + 1)) == (lastInsertIndex >> (i + 1))) {
+                self.lastSubtrees[i][proofPathIndices[i]] = hash;
+            }
 
             if (proofPathIndices[i] == 0) {
-                if (proofSiblings[i] == self.lastSubtrees[i][1]) {
-                    self.lastSubtrees[i][0] = hash;
-                }
-
                 hash = PoseidonT3.hash([hash, proofSiblings[i]]);
             } else {
-                if (proofSiblings[i] == self.lastSubtrees[i][0]) {
-                    self.lastSubtrees[i][1] = hash;
-                }
-
                 hash = PoseidonT3.hash([proofSiblings[i], hash]);
             }
 
             unchecked {
                 ++i;
             }
-        }
-
-        if (updateIndex >= self.numberOfLeaves) {
-            revert LeafIndexOutOfRange();
         }
 
         self.root = hash;

--- a/packages/imt/contracts/InternalQuinaryIMT.sol
+++ b/packages/imt/contracts/InternalQuinaryIMT.sol
@@ -125,11 +125,27 @@ library InternalQuinaryIMT {
 
         uint256 depth = self.depth;
         uint256 hash = newLeaf;
-        uint256 updateIndex;
+
+        uint256 updateLeafIndex;
+        for (uint8 i = 0; i < depth; ) {
+            updateLeafIndex += uint256(proofPathIndices[i]) * (5 ** i);
+            unchecked {
+                ++i;
+            }
+        }
+
+        uint256 numberOfLeaves = self.numberOfLeaves;
+
+        if (updateLeafIndex >= numberOfLeaves) {
+            revert LeafIndexOutOfRange();
+        }
+
+        // Track parent indices incrementally (dividing by 5 each level)
+        uint256 lastParentIndex = numberOfLeaves - 1;
+        uint256 updateParentIndex = updateLeafIndex;
 
         for (uint8 i = 0; i < depth; ) {
             uint256[5] memory nodes;
-            updateIndex += proofPathIndices[i] * 5 ** i;
 
             for (uint8 j = 0; j < 5; ) {
                 if (j < proofPathIndices[i]) {
@@ -144,7 +160,12 @@ library InternalQuinaryIMT {
                 }
             }
 
-            if (nodes[0] == self.lastSubtrees[i][0] || nodes[4] == self.lastSubtrees[i][4]) {
+            lastParentIndex /= 5;
+            updateParentIndex /= 5;
+
+            // Update lastSubtrees only when update and last insertion
+            // share the same parent node at level i+1
+            if (lastParentIndex == updateParentIndex) {
                 self.lastSubtrees[i][proofPathIndices[i]] = hash;
             }
 
@@ -153,10 +174,6 @@ library InternalQuinaryIMT {
             unchecked {
                 ++i;
             }
-        }
-
-        if (updateIndex >= self.numberOfLeaves) {
-            revert LeafIndexOutOfRange();
         }
 
         self.root = hash;

--- a/packages/imt/test/BinaryIMT.ts
+++ b/packages/imt/test/BinaryIMT.ts
@@ -206,6 +206,63 @@ describe("BinaryIMT", () => {
             expect(root).to.equal(jsBinaryIMT.root)
         })
 
+        it("Should correctly maintain lastSubtrees after update and following insert", async () => {
+            const depth = 4
+            const jsBinaryIMT2 = new JSBinaryIMT(poseidon2, depth, 0, 2)
+            await binaryIMTTest.init(depth)
+
+            // Insert 4 leaves
+            for (let i = 1; i <= 4; i++) {
+                jsBinaryIMT2.insert(i)
+                await binaryIMTTest.insert(i)
+            }
+
+            // Update leaf at index 0 (different path from last insert at index 3)
+            const { pathIndices, siblings } = jsBinaryIMT2.createProof(0)
+            jsBinaryIMT2.update(0, 10)
+            await binaryIMTTest.update(
+                1,
+                10,
+                siblings.map((s) => s[0]),
+                pathIndices
+            )
+
+            // Insert another leaf (this uses lastSubtrees which must be correct)
+            jsBinaryIMT2.insert(5)
+            await binaryIMTTest.insert(5)
+
+            const { root } = await binaryIMTTest.data()
+            expect(root).to.equal(jsBinaryIMT2.root)
+        })
+
+        it("Should correctly maintain lastSubtrees after remove and following insert", async () => {
+            const depth = 4
+            const jsBinaryIMT2 = new JSBinaryIMT(poseidon2, depth, 0, 2)
+            await binaryIMTTest.init(depth)
+
+            // Insert 4 leaves
+            for (let i = 1; i <= 4; i++) {
+                jsBinaryIMT2.insert(i)
+                await binaryIMTTest.insert(i)
+            }
+
+            // Remove leaf at index 0
+            const { pathIndices, siblings } = jsBinaryIMT2.createProof(0)
+            jsBinaryIMT2.delete(0)
+            await binaryIMTTest.remove(
+                1,
+                siblings.map((s) => s[0]),
+                pathIndices
+            )
+
+            // Insert another leaf (uses lastSubtrees)
+            jsBinaryIMT2.insert(5)
+            await binaryIMTTest.insert(5)
+
+            const { root } = await binaryIMTTest.data()
+            expect(root).to.equal(jsBinaryIMT2.root)
+        })
+
         it("Should not update a leaf that hasn't been inserted yet", async () => {
             binaryIMTTest.init(jsBinaryIMT.depth)
 

--- a/packages/imt/test/QuinaryIMT.ts
+++ b/packages/imt/test/QuinaryIMT.ts
@@ -155,6 +155,54 @@ describe("QuinaryIMT", () => {
             expect(root).to.equal(jsQuinaryIMT.root)
         })
 
+        it("Should correctly maintain lastSubtrees after update and following insert", async () => {
+            const depth = 4
+            const jsQuinaryIMT2 = new JSQuinaryIMT(poseidon5, depth, 0, 5)
+            await quinaryIMTTest.init(depth)
+
+            // Insert 6 leaves (fills group 0, starts group 1)
+            for (let i = 1; i <= 6; i++) {
+                jsQuinaryIMT2.insert(i)
+                await quinaryIMTTest.insert(i)
+            }
+
+            // Update leaf at index 0 (group 0, different from last insert in group 1)
+            const { pathIndices, siblings } = jsQuinaryIMT2.createProof(0)
+            jsQuinaryIMT2.update(0, 10)
+            await quinaryIMTTest.update(1, 10, siblings, pathIndices)
+
+            // Insert another leaf (this uses lastSubtrees which must be correct)
+            jsQuinaryIMT2.insert(7)
+            await quinaryIMTTest.insert(7)
+
+            const { root } = await quinaryIMTTest.data()
+            expect(root).to.equal(jsQuinaryIMT2.root)
+        })
+
+        it("Should correctly maintain lastSubtrees after remove and following insert", async () => {
+            const depth = 4
+            const jsQuinaryIMT2 = new JSQuinaryIMT(poseidon5, depth, 0, 5)
+            await quinaryIMTTest.init(depth)
+
+            // Insert 6 leaves
+            for (let i = 1; i <= 6; i++) {
+                jsQuinaryIMT2.insert(i)
+                await quinaryIMTTest.insert(i)
+            }
+
+            // Remove leaf at index 0
+            const { pathIndices, siblings } = jsQuinaryIMT2.createProof(0)
+            jsQuinaryIMT2.delete(0)
+            await quinaryIMTTest.remove(1, siblings, pathIndices)
+
+            // Insert another leaf
+            jsQuinaryIMT2.insert(7)
+            await quinaryIMTTest.insert(7)
+
+            const { root } = await quinaryIMTTest.data()
+            expect(root).to.equal(jsQuinaryIMT2.root)
+        })
+
         it("Should not update a leaf that hasn't been inserted yet", async () => {
             quinaryIMTTest.init(jsQuinaryIMT.depth)
 


### PR DESCRIPTION
## Description

This PR fixes `_update` in both `InternalBinaryIMT` and `InternalQuinaryIMT` by replacing the value-based equality checks on `lastSubtrees` with deterministic index-based parent comparison. 

Now we only update `lastSubtrees[i]` when the update and last-insert paths share the same parent node at level i+1. Also moved the bounds check before the main loop to prevent a uint256 underflow panic on empty trees     

## Related Issue(s)

Closes #41 

## Checklist

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
